### PR TITLE
Fix missing blas library at link time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,13 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
 
   if(BLAS)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fexternal-blas ${BLAS}")
+    set(LIBS "${LIBS} blas")
     message(STATUS "Configuring build to use BLAS from ${BLAS}")
   endif()
     
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C -fbacktrace")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -ffast-math")
-
 endif()
 
 # compiler flags for ifort
@@ -67,16 +67,19 @@ endif()
 # library to archive (libneural.a)
 add_library(neural src/lib/mod_activation.f90 src/lib/mod_io.f90 src/lib/mod_kinds.f90 src/lib/mod_layer.f90 src/lib/mod_mnist.f90 src/lib/mod_network.f90 src/lib/mod_parallel.f90 src/lib/mod_random.f90)
 
+# Remove leading or trailing whitespace
+string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
+
 # tests
 enable_testing()
 foreach(execid mnist network_save network_sync)
   add_executable(test_${execid} src/tests/test_${execid}.f90)
-  target_link_libraries(test_${execid} neural)
+  target_link_libraries(test_${execid} neural ${LIBS})
   add_test(test_${execid} bin/test_${execid})
 endforeach()
   
 foreach(execid mnist simple sine)
   add_executable(example_${execid} src/tests/example_${execid}.f90)
-  target_link_libraries(example_${execid} neural)
+  target_link_libraries(example_${execid} neural ${LIBS})
   add_test(example_${execid} bin/example_${execid})
 endforeach()


### PR DESCRIPTION
I tried to compile with `cmake .. -dBLAS=-lblas` and got 
```
lib/libneural.so : référence indéfinie vers « sgemm_ »
collect2: error: ld returned 1 exit status
CMakeFiles/example_sine.dir/build.make:95: recipe for target 'bin/example_sine' failed
make[2]: *** [bin/example_sine] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/example_sine.dir/all' failed
make[1]: *** [CMakeFiles/example_sine.dir/all] Error 2
Makefile:94: recipe for target 'all' failed
make: *** [all] Error 2
```
This pull request solves this.

