### PR TITLE
Fix MNIST relative path and add instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ in parallel, respectively:
 fpm build --compiler caf --flag "-cpp -DCAF -O3 -ffast-math"
 ```
 
+#### Testing with fpm
+
+```
+fpm test --flag "-cpp -O3 -ffast-math -fcoarray=single"
+```
+
+For the time being, you need to specify the same compiler flags to `fpm test`
+as you did in `fpm build` so that fpm can figure out to use the same build
+profile.
+
 See [Fortran Package Manager](https://github.com/fortran-lang/fpm) for more info on fpm.
 
 ### Building with CMake
@@ -134,6 +144,25 @@ To build with debugging flags enabled, type:
 ```
 cmake .. -DCMAKE_BUILD_TYPE=debug
 ```
+
+#### Running tests with CMake
+
+Before running the tests, link the the data/ directory to the current directory:
+
+```
+ln -s ../data
+```
+
+The MNIST dataset which comes with the code as a tarball must be unpacked first.
+See [MNIST training example](#mnist-training-example) on how to do that.
+Once the MNIST dataset is unpacked and the data/ directory is linked in your
+CMake build/ directory, run
+
+```
+ctest
+```
+
+to run the tests.
 
 ## Examples
 

--- a/src/mod_mnist.f90
+++ b/src/mod_mnist.f90
@@ -49,20 +49,20 @@ contains
     integer(ik), parameter :: te_nimages = 10000
     integer(ik), parameter :: va_nimages = 10000
 
-    call read_binary_file('../data/mnist/mnist_training_images.dat',&
+    call read_binary_file('data/mnist/mnist_training_images.dat',&
                           dtype, image_size, tr_nimages, tr_images)
-    call read_binary_file('../data/mnist/mnist_training_labels.dat',&
+    call read_binary_file('data/mnist/mnist_training_labels.dat',&
                           dtype, tr_nimages, tr_labels)
 
-    call read_binary_file('../data/mnist/mnist_testing_images.dat',&
+    call read_binary_file('data/mnist/mnist_testing_images.dat',&
                           dtype, image_size, te_nimages, te_images)
-    call read_binary_file('../data/mnist/mnist_testing_labels.dat',&
+    call read_binary_file('data/mnist/mnist_testing_labels.dat',&
                           dtype, te_nimages, te_labels)
 
     if (present(va_images) .and. present(va_labels)) then
-      call read_binary_file('../data/mnist/mnist_validation_images.dat',&
+      call read_binary_file('data/mnist/mnist_validation_images.dat',&
                             dtype, image_size, va_nimages, va_images)
-      call read_binary_file('../data/mnist/mnist_validation_labels.dat',&
+      call read_binary_file('data/mnist/mnist_validation_labels.dat',&
                             dtype, va_nimages, va_labels)
     end if
 


### PR DESCRIPTION
@rouson In trying out different approaches, I took the minimal one:

1. Prioritize fpm which must run from root project dir, so set the canonical relative data path to be data/mnist.
2. Add instructions on running tests to the README.md

Fixes #35.