### PR TITLE
Refactor: move procedure definitions to submodules

### DIFF
--- a/src/mod_layer.f90
+++ b/src/mod_layer.f90
@@ -4,7 +4,7 @@ module mod_layer
 
   use mod_activation
   use mod_kinds, only: ik, rk
-  use mod_random, only: randn
+  use nf_random_mod, only: randn
 
   implicit none
 

--- a/src/mod_random.f90
+++ b/src/mod_random.f90
@@ -10,30 +10,21 @@ module mod_random
   private
   public :: randn
 
-  real(rk), parameter :: pi = 4 * atan(1._rk)
-
   interface randn
-    module procedure :: randn1d, randn2d
+
+    module function randn1d(n) result(r)
+      ! Generates n random numbers with a normal distribution.
+      implicit none
+      integer(ik), intent(in) :: n
+      real(rk) :: r(n)
+    end function randn1d
+
+    module function randn2d(m, n) result(r)
+      ! Generates m x n random numbers with a normal distribution.
+      integer(ik), intent(in) :: m, n
+      real(rk) :: r(m, n)
+    end function randn2d
+  
   end interface randn
-
-contains
-
-  function randn1d(n) result(r)
-    ! Generates n random numbers with a normal distribution.
-    integer(ik), intent(in) :: n
-    real(rk) :: r(n), r2(n)
-    call random_number(r)
-    call random_number(r2)
-    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
-  end function randn1d
-
-  function randn2d(m, n) result(r)
-    ! Generates m x n random numbers with a normal distribution.
-    integer(ik), intent(in) :: m, n
-    real(rk) :: r(m, n), r2(m, n)
-    call random_number(r)
-    call random_number(r2)
-    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
-  end function randn2d
 
 end module mod_random

--- a/src/nf_random_mod.f90
+++ b/src/nf_random_mod.f90
@@ -1,4 +1,4 @@
-module mod_random
+module nf_random_mod
 
   ! Provides a random number generator with
   ! normal distribution, centered on zero.
@@ -27,4 +27,4 @@ module mod_random
   
   end interface randn
 
-end module mod_random
+end module nf_random_mod

--- a/src/nf_random_s.f90
+++ b/src/nf_random_s.f90
@@ -1,0 +1,26 @@
+submodule(mod_random) submod_random
+
+  ! Provides a random number generator with
+  ! normal distribution, centered on zero.
+
+  implicit none
+
+  real(rk), parameter :: pi = 4 * atan(1._rk)
+
+contains
+
+  module procedure randn1d
+    real(rk) :: r2(n)
+    call random_number(r)
+    call random_number(r2)
+    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
+  end procedure randn1d
+
+  module procedure randn2d
+    real(rk) :: r2(m, n)
+    call random_number(r)
+    call random_number(r2)
+    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
+  end procedure randn2d
+
+end submodule submod_random

--- a/src/nf_random_submod.f90
+++ b/src/nf_random_submod.f90
@@ -1,4 +1,4 @@
-submodule(mod_random) submod_random
+submodule(nf_random_mod) nf_random_submod
 
   ! Provides a random number generator with
   ! normal distribution, centered on zero.
@@ -23,4 +23,4 @@ contains
     r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
   end procedure randn2d
 
-end submodule submod_random
+end submodule nf_random_submod


### PR DESCRIPTION
This PR demonstrates an example of separating procedure interface bodies (in a module) from procedure definitions (in a submodule).  In current form, the PR applies this process only to what was originally named `mod_random`.

Benefits:
1. Reduces the information a user encounters when attempting to use a module.
2. Clarifies what parts of the module are part of the API.  For example,
   - A procedure's local variables no longer appear in the module.  
   - A non-`public` module entity (e.g., `pi`)  no longer appears in the module.
  
This PR also proposes a new scheme for file, module, and submodule names:   
* Prefix `nf_` to reduce name clashes with other projects,
* Suffix `_mod` for modules, and
* Suffix `_submod` for submodules.

If approved, this PR can be updated to apply similar changes to the rest of the files in `src/`:
- [ ] mod_activation.f90
- [ ] mod_kinds.f90
- [ ] mod_mnist.f90
- [ ] mod_parallel.f90
- [ ] mod_io.f90
- [ ] mod_layer.f90
- [ ] mod_network.f90