### PR TITLE
Add FORD project file & convert comments to FORD style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.mod
 build
 data/*/*.dat
+doc

--- a/doc-generator.md
+++ b/doc-generator.md
@@ -1,0 +1,30 @@
+project: neural-fortran
+summary: A parallel neural net microframework
+src_dir: src
+output_dir: doc/html
+preprocess: true
+macro: FORD
+preprocessor: gfortran -E
+display: public
+         protected
+         private
+source: true
+graph: true
+md_extensions: markdown.extensions.toc
+coloured_edges: true
+sort: permission-alpha
+extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORTRAN_005fENV.html
+            iso_c_binding:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html#ISO_005fC_005fBINDING
+project_github: https://github.com/sourceryinstitute/dag
+author: Milan Curcic
+print_creation_date: true
+creation_date: %Y-%m-%d %H:%M %z
+project_github: https://github.com/modern-fortran/neural-fortran
+project_download: https://github.com/modern-fortran/neural-fortran/releases
+github: https://github.com/modern-fortran
+predocmark_alt: >
+predocmark: <
+docmark_alt:
+docmark: !
+
+{!README.md!}

--- a/src/mod_layer.f90
+++ b/src/mod_layer.f90
@@ -4,7 +4,7 @@ module mod_layer
 
   use mod_activation
   use mod_kinds, only: ik, rk
-  use mod_random, only: randn
+  use nf_random_mod, only: randn
 
   implicit none
 

--- a/src/mod_random.f90
+++ b/src/mod_random.f90
@@ -10,30 +10,21 @@ module mod_random
   private
   public :: randn
 
-  real(rk), parameter :: pi = 4 * atan(1._rk)
-
   interface randn
-    module procedure :: randn1d, randn2d
+
+    module function randn1d(n) result(r)
+      ! Generates n random numbers with a normal distribution.
+      implicit none
+      integer(ik), intent(in) :: n
+      real(rk) :: r(n)
+    end function randn1d
+
+    module function randn2d(m, n) result(r)
+      ! Generates m x n random numbers with a normal distribution.
+      integer(ik), intent(in) :: m, n
+      real(rk) :: r(m, n)
+    end function randn2d
+  
   end interface randn
-
-contains
-
-  function randn1d(n) result(r)
-    ! Generates n random numbers with a normal distribution.
-    integer(ik), intent(in) :: n
-    real(rk) :: r(n), r2(n)
-    call random_number(r)
-    call random_number(r2)
-    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
-  end function randn1d
-
-  function randn2d(m, n) result(r)
-    ! Generates m x n random numbers with a normal distribution.
-    integer(ik), intent(in) :: m, n
-    real(rk) :: r(m, n), r2(m, n)
-    call random_number(r)
-    call random_number(r2)
-    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
-  end function randn2d
 
 end module mod_random

--- a/src/nf_random_mod.f90
+++ b/src/nf_random_mod.f90
@@ -1,4 +1,4 @@
-module mod_random
+module nf_random_mod
 
   ! Provides a random number generator with
   ! normal distribution, centered on zero.
@@ -27,4 +27,4 @@ module mod_random
   
   end interface randn
 
-end module mod_random
+end module nf_random_mod

--- a/src/nf_random_mod.f90
+++ b/src/nf_random_mod.f90
@@ -1,7 +1,6 @@
 module nf_random_mod
-
-  ! Provides a random number generator with
-  ! normal distribution, centered on zero.
+  !! Provides a random number generator with
+  !! normal distribution, centered on zero.
 
   use mod_kinds, only: ik, rk
 
@@ -13,14 +12,14 @@ module nf_random_mod
   interface randn
 
     module function randn1d(n) result(r)
-      ! Generates n random numbers with a normal distribution.
+      !! Generates n random numbers with a normal distribution.
       implicit none
       integer(ik), intent(in) :: n
       real(rk) :: r(n)
     end function randn1d
 
     module function randn2d(m, n) result(r)
-      ! Generates m x n random numbers with a normal distribution.
+      !! Generates m x n random numbers with a normal distribution.
       integer(ik), intent(in) :: m, n
       real(rk) :: r(m, n)
     end function randn2d

--- a/src/nf_random_s.f90
+++ b/src/nf_random_s.f90
@@ -1,0 +1,26 @@
+submodule(mod_random) submod_random
+
+  ! Provides a random number generator with
+  ! normal distribution, centered on zero.
+
+  implicit none
+
+  real(rk), parameter :: pi = 4 * atan(1._rk)
+
+contains
+
+  module procedure randn1d
+    real(rk) :: r2(n)
+    call random_number(r)
+    call random_number(r2)
+    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
+  end procedure randn1d
+
+  module procedure randn2d
+    real(rk) :: r2(m, n)
+    call random_number(r)
+    call random_number(r2)
+    r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
+  end procedure randn2d
+
+end submodule submod_random

--- a/src/nf_random_submod.f90
+++ b/src/nf_random_submod.f90
@@ -1,7 +1,6 @@
 submodule(nf_random_mod) nf_random_submod
-
-  ! Provides a random number generator with
-  ! normal distribution, centered on zero.
+  !! Provides a random number generator with
+  !! normal distribution, centered on zero.
 
   implicit none
 

--- a/src/nf_random_submod.f90
+++ b/src/nf_random_submod.f90
@@ -1,4 +1,4 @@
-submodule(mod_random) submod_random
+submodule(nf_random_mod) nf_random_submod
 
   ! Provides a random number generator with
   ! normal distribution, centered on zero.
@@ -23,4 +23,4 @@ contains
     r = sqrt(-2 * log(r)) * cos(2 * pi * r2)
   end procedure randn2d
 
-end submodule submod_random
+end submodule nf_random_submod


### PR DESCRIPTION
1. Add a top-level `doc-generator.md` FORD project file that produces HTML documentation inside `doc/html/` and includes the top-level `README.md` content in the landing page: `doc/html/index.html`.
2. Replaces `!` with `!!` in comments _only_ in the `nf_random_mod` just after the first line of the module and just after the first lines of the procedure interface bodies.  Doing so triggers for to include the corresponding comments in the generated documentation. 
3. Add the `doc/` subdirectory to the `.gitignore` file.

If this PR gets merged, then executing
```
cd neural-fortran
ford doc-generator.md
```
will produce an uncompressed version of [doc.tar.gz](https://github.com/modern-fortran/neural-fortran/files/8422580/doc.tar.gz).

If approved, this PR can be updated to apply similar changes to the rest of the files in `src/`:
- [ ] mod_activation.f90
- [ ] mod_kinds.f90
- [ ] mod_mnist.f90
- [ ] mod_parallel.f90
- [ ] mod_io.f90
- [ ] mod_layer.f90
- [ ] mod_network.f90

.