### PR TITLE
Delete CAF C preprocessor macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ if(SERIAL)
   message(STATUS "Configuring build for serial execution")
 else()
   message(STATUS "Configuring build for parallel execution")
-  add_definitions(-DCAF)
 endif()
 
 # compiler flags for gfortran
@@ -59,6 +58,11 @@ endif()
 
 # compiler flags for ifort
 if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+
+  if(SERIAL)
+    message(STATUS "Configuring to build with -coarray=single")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -coarray=single")
+  endif()
 
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -assume byterecl,realloc_lhs -heap-arrays")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -C -traceback")

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Once installed, use the compiler wrappers `caf` and `cafrun` to build and execut
 in parallel, respectively:
 
 ```
-fpm build --compiler caf --flag "-cpp -DCAF -O3 -ffast-math"
+fpm build --compiler caf --flag "-cpp -O3 -ffast-math"
 ```
 
 #### Testing with fpm

--- a/src/mod_layer_submodule.f90
+++ b/src/mod_layer_submodule.f90
@@ -56,9 +56,7 @@ contains
     type(array1d), allocatable, intent(in out) :: db(:)
     integer(ik) :: n
     do n = 2, size(db)
-#ifdef CAF
       call co_sum(db(n) % array)
-#endif
     end do
   end subroutine db_co_sum
   
@@ -66,9 +64,7 @@ contains
     type(array2d), allocatable, intent(in out) :: dw(:)
     integer(ik) :: n
     do n = 1, size(dw) - 1
-#ifdef CAF
       call co_sum(dw(n) % array)
-#endif
     end do
   end subroutine dw_co_sum
   

--- a/src/mod_network_submodule.f90
+++ b/src/mod_network_submodule.f90
@@ -190,10 +190,8 @@ contains
     integer(ik) :: n
     if (num_images() == 1) return
     layers: do n = 1, size(self % dims)
-#ifdef CAF
       call co_broadcast(self % layers(n) % b, image)
       call co_broadcast(self % layers(n) % w, image)
-#endif
     end do layers
   end subroutine sync
 


### PR DESCRIPTION
This PR includes all of the commits from PR #51 plus one additional commit that removes the `CAF` C preprocessor macro.  Because the macro appears only in procedure definitions and never in interfaces, it would be impractical to create this PR without including the commits from PR #51 because the latter PR moves all procedure definitions to new files.