### PR TITLE
Workaround for submodule-related bug in GFortran-9

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Dependencies:
 
 Compilers tested include:
 
-* gfortran-10.3.0
+* gfortran-9.4.0
 * ifort-2021.4
 * ifx-2021.4
 

--- a/src/mod_parallel_submodule.f90
+++ b/src/mod_parallel_submodule.f90
@@ -5,22 +5,22 @@ submodule(mod_parallel) mod_parallel_submodule
 
 contains
 
-  pure module function tile_indices(dims)
+  pure module function tile_indices(dims) result(res)
     integer(ik), intent(in) :: dims
-    integer(ik) :: tile_indices(2)
+    integer(ik) :: res(2)
     integer(ik) :: offset, tile_size
 
     tile_size = dims / num_images()
 
     !! start and end indices assuming equal tile sizes
-    tile_indices(1) = (this_image() - 1) * tile_size + 1
-    tile_indices(2) = tile_indices(1) + tile_size - 1
+    res(1) = (this_image() - 1) * tile_size + 1
+    res(2) = res(1) + tile_size - 1
 
     !! if we have any remainder, distribute it to the tiles at the end
     offset = num_images() - mod(dims, num_images())
     if (this_image() > offset) then
-      tile_indices(1) = tile_indices(1) + this_image() - offset - 1
-      tile_indices(2) = tile_indices(2) + this_image() - offset
+      res(1) = res(1) + this_image() - offset - 1
+      res(2) = res(2) + this_image() - offset
     end if
 
   end function tile_indices


### PR DESCRIPTION
This PR only changes the syntax of one function definition as a workaround for what seems to be a bug in GFortran-9.4.0.

With this change, GFortran-9.4.0 now builds neural-fortran.