### PR TITLE
Implement a flatten layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(neural
   src/nf_datasets_mnist_submodule.f90
   src/nf_dense_layer.f90
   src/nf_dense_layer_submodule.f90
+  src/nf_flatten_layer.f90
+  src/nf_flatten_layer_submodule.f90
   src/nf.f90
   src/nf_input1d_layer.f90
   src/nf_input1d_layer_submodule.f90
@@ -102,7 +104,7 @@ string(REGEX REPLACE "^ | $" "" LIBS "${LIBS}")
 
 # tests
 enable_testing()
-foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer dense_network conv2d_network)
+foreach(execid input1d_layer input3d_layer dense_layer conv2d_layer maxpool2d_layer flatten_layer dense_network conv2d_network)
   add_executable(test_${execid} test/test_${execid}.f90)
   target_link_libraries(test_${execid} neural ${LIBS})
   add_test(test_${execid} bin/test_${execid})

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 | Dense (fully-connected) | `dense` | `input` (1-d) | 1 | ✅ | ✅ |
 | Convolutional (2-d) | `conv2d` | `input` (3-d), `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
 | Max-pooling (2-d) | `maxpool2d` | `input` (3-d), `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
+| Flatten | `flatten` | `input` (3-d), `conv2d`, `maxpool2d` | 1 | ✅ | ✅ |
 
 ## Getting started
 

--- a/src/nf.f90
+++ b/src/nf.f90
@@ -1,6 +1,6 @@
 module nf
   use nf_datasets_mnist, only: label_digits, load_mnist
   use nf_layer, only: layer
-  use nf_layer_constructors, only: conv2d, dense, input, maxpool2d
+  use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d
   use nf_network, only: network
 end module nf

--- a/src/nf_flatten_layer.f90
+++ b/src/nf_flatten_layer.f90
@@ -15,9 +15,10 @@ module nf_flatten_layer
 
     !! Concrete implementation of a flatten (3-d to 1-d) layer.
 
-    integer :: input_shape
+    integer, allocatable :: input_shape(:)
     integer :: output_size
 
+    real, allocatable :: gradient(:,:,:)
     real, allocatable :: output(:)
 
   contains
@@ -39,11 +40,10 @@ module nf_flatten_layer
   interface
 
     pure module subroutine backward(self, input, gradient)
-      !! Apply the backward gradient descent pass.
-      !! Only weight and bias gradients are updated in this subroutine,
-      !! while the weights and biases themselves are untouched.
+      !! Apply the backward pass to the flatten layer.
+      !! This is a reshape operation from 1-d gradient to 3-d input.
       class(flatten_layer), intent(in out) :: self
-        !! Dense layer instance
+        !! Flatten layer instance
       real, intent(in) :: input(:,:,:)
         !! Input from the previous layer
       real, intent(in) :: gradient(:)

--- a/src/nf_flatten_layer.f90
+++ b/src/nf_flatten_layer.f90
@@ -1,0 +1,75 @@
+module nf_flatten_layer
+
+  !! This module provides the concrete flatten layer type.
+  !! It is used internally by the layer type.
+  !! It is not intended to be used directly by the user.
+
+  use nf_base_layer, only: base_layer
+
+  implicit none
+
+  private
+  public :: flatten_layer
+
+  type, extends(base_layer) :: flatten_layer
+
+    !! Concrete implementation of a flatten (3-d to 1-d) layer.
+
+    integer :: input_shape
+    integer :: output_size
+
+    real, allocatable :: output(:)
+
+  contains
+
+    procedure :: backward
+    procedure :: forward
+    procedure :: init
+
+  end type flatten_layer
+
+  interface flatten_layer
+    elemental module function flatten_layer_cons() result(res)
+      !! This function returns the `flatten_layer` instance.
+      type(flatten_layer) :: res
+        !! `flatten_layer` instance
+    end function flatten_layer_cons
+  end interface flatten_layer
+
+  interface
+
+    pure module subroutine backward(self, input, gradient)
+      !! Apply the backward gradient descent pass.
+      !! Only weight and bias gradients are updated in this subroutine,
+      !! while the weights and biases themselves are untouched.
+      class(flatten_layer), intent(in out) :: self
+        !! Dense layer instance
+      real, intent(in) :: input(:,:,:)
+        !! Input from the previous layer
+      real, intent(in) :: gradient(:)
+        !! Gradient from the next layer
+    end subroutine backward
+
+    pure module subroutine forward(self, input)
+      !! Propagate forward the layer.
+      !! Calling this subroutine updates the values of a few data components
+      !! of `flatten_layer` that are needed for the backward pass.
+      class(flatten_layer), intent(in out) :: self
+        !! Dense layer instance
+      real, intent(in) :: input(:,:,:)
+        !! Input from the previous layer
+    end subroutine forward
+
+    module subroutine init(self, input_shape)
+      !! Initialize the layer data structures.
+      !!
+      !! This is a deferred procedure from the `base_layer` abstract type.
+      class(flatten_layer), intent(in out) :: self
+        !! Dense layer instance
+      integer, intent(in) :: input_shape(:)
+        !! Shape of the input layer
+    end subroutine init
+
+  end interface
+
+end module nf_flatten_layer

--- a/src/nf_flatten_layer_submodule.f90
+++ b/src/nf_flatten_layer_submodule.f90
@@ -38,7 +38,7 @@ contains
     self % output_size = product(input_shape)
 
     allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
-    self % output = 0
+    self % gradient = 0
 
     allocate(self % output(self % output_size))
     self % output = 0

--- a/src/nf_flatten_layer_submodule.f90
+++ b/src/nf_flatten_layer_submodule.f90
@@ -19,18 +19,30 @@ contains
     class(flatten_layer), intent(in out) :: self
     real, intent(in) :: input(:,:,:)
     real, intent(in) :: gradient(:)
+    self % gradient = reshape(gradient, shape(input))
   end subroutine backward
 
 
   pure module subroutine forward(self, input)
     class(flatten_layer), intent(in out) :: self
     real, intent(in) :: input(:,:,:)
+    self % output = pack(input, .true.)
   end subroutine forward
 
 
   module subroutine init(self, input_shape)
     class(flatten_layer), intent(in out) :: self
     integer, intent(in) :: input_shape(:)
+
+    self % input_shape = input_shape
+    self % output_size = product(input_shape)
+
+    allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
+    self % output = 0
+
+    allocate(self % output(self % output_size))
+    self % output = 0
+
   end subroutine init
 
 end submodule nf_flatten_layer_submodule

--- a/src/nf_flatten_layer_submodule.f90
+++ b/src/nf_flatten_layer_submodule.f90
@@ -1,0 +1,36 @@
+submodule(nf_flatten_layer) nf_flatten_layer_submodule
+
+  !! This module provides the concrete flatten layer type.
+  !! It is used internally by the layer type.
+  !! It is not intended to be used directly by the user.
+
+  use nf_base_layer, only: base_layer
+
+  implicit none
+
+contains
+
+  elemental module function flatten_layer_cons() result(res)
+    type(flatten_layer) :: res
+  end function flatten_layer_cons
+
+
+  pure module subroutine backward(self, input, gradient)
+    class(flatten_layer), intent(in out) :: self
+    real, intent(in) :: input(:,:,:)
+    real, intent(in) :: gradient(:)
+  end subroutine backward
+
+
+  pure module subroutine forward(self, input)
+    class(flatten_layer), intent(in out) :: self
+    real, intent(in) :: input(:,:,:)
+  end subroutine forward
+
+
+  module subroutine init(self, input_shape)
+    class(flatten_layer), intent(in out) :: self
+    integer, intent(in) :: input_shape(:)
+  end subroutine init
+
+end submodule nf_flatten_layer_submodule

--- a/src/nf_layer_constructors.f90
+++ b/src/nf_layer_constructors.f90
@@ -7,7 +7,7 @@ module nf_layer_constructors
   implicit none
 
   private
-  public :: conv2d, dense, input, maxpool2d
+  public :: conv2d, dense, flatten, input, maxpool2d
 
   interface input
 
@@ -83,6 +83,27 @@ module nf_layer_constructors
       type(layer) :: res
         !! Resulting layer instance
     end function dense
+
+    pure module function flatten() result(res)
+      !! Flatten (3-d -> 1-d) layer constructor.
+      !!
+      !! Use this layer to chain layers with 3-d outputs to layers with 1-d
+      !! inputs. For example, to chain a `conv2d` or a `maxpool2d` layer
+      !! with a `dense` layer for a CNN for classification, place a `flatten`
+      !! layer between them.
+      !!
+      !! A flatten layer must not be the first layer in the network.
+      !!
+      !! Example:
+      !!
+      !! ```
+      !! use nf, only :: flatten, layer
+      !! type(layer) :: flatten_layer
+      !! flatten_layer = flatten()
+      !! ```
+      type(layer) :: res
+        !! Resulting layer instance
+    end function flatten
 
     pure module function conv2d(filters, kernel_size, activation) result(res)
       !! 2-d convolutional layer constructor.

--- a/src/nf_layer_constructors_submodule.f90
+++ b/src/nf_layer_constructors_submodule.f90
@@ -3,6 +3,7 @@ submodule(nf_layer_constructors) nf_layer_constructors_submodule
   use nf_layer, only: layer
   use nf_conv2d_layer, only: conv2d_layer
   use nf_dense_layer, only: dense_layer
+  use nf_flatten_layer, only: flatten_layer
   use nf_input1d_layer, only: input1d_layer
   use nf_input3d_layer, only: input3d_layer
   use nf_maxpool2d_layer, only: maxpool2d_layer
@@ -10,47 +11,6 @@ submodule(nf_layer_constructors) nf_layer_constructors_submodule
   implicit none
 
 contains
-
-  pure module function input1d(layer_size) result(res)
-    integer, intent(in) :: layer_size
-    type(layer) :: res
-    res % name = 'input'
-    res % layer_shape = [layer_size]
-    res % input_layer_shape = [integer ::]
-    allocate(res % p, source=input1d_layer(layer_size))
-    res % initialized = .true.
-  end function input1d
-
-
-  pure module function input3d(layer_shape) result(res)
-    integer, intent(in) :: layer_shape(3)
-    type(layer) :: res
-    res % name = 'input'
-    res % layer_shape = layer_shape
-    res % input_layer_shape = [integer ::]
-    allocate(res % p, source=input3d_layer(layer_shape))
-    res % initialized = .true.
-  end function input3d
-
-
-  pure module function dense(layer_size, activation) result(res)
-    integer, intent(in) :: layer_size
-    character(*), intent(in), optional :: activation
-    type(layer) :: res
-
-    res % name = 'dense'
-    res % layer_shape = [layer_size]
-
-    if (present(activation)) then
-      res % activation = activation
-    else
-      res % activation = 'sigmoid'
-    end if
-
-    allocate(res % p, source=dense_layer(layer_size, res % activation))
-
-  end function dense
-
 
   pure module function conv2d(filters, kernel_size, activation) result(res)
     integer, intent(in) :: filters
@@ -73,6 +33,53 @@ contains
 
   end function conv2d
 
+
+  pure module function dense(layer_size, activation) result(res)
+    integer, intent(in) :: layer_size
+    character(*), intent(in), optional :: activation
+    type(layer) :: res
+
+    res % name = 'dense'
+    res % layer_shape = [layer_size]
+
+    if (present(activation)) then
+      res % activation = activation
+    else
+      res % activation = 'sigmoid'
+    end if
+
+    allocate(res % p, source=dense_layer(layer_size, res % activation))
+
+  end function dense
+
+
+  pure module function flatten() result(res)
+    type(layer) :: res
+    res % name = 'flatten'
+    allocate(res % p, source=flatten_layer())
+  end function flatten
+
+
+  pure module function input1d(layer_size) result(res)
+    integer, intent(in) :: layer_size
+    type(layer) :: res
+    res % name = 'input'
+    res % layer_shape = [layer_size]
+    res % input_layer_shape = [integer ::]
+    allocate(res % p, source=input1d_layer(layer_size))
+    res % initialized = .true.
+  end function input1d
+
+
+  pure module function input3d(layer_shape) result(res)
+    integer, intent(in) :: layer_shape(3)
+    type(layer) :: res
+    res % name = 'input'
+    res % layer_shape = layer_shape
+    res % input_layer_shape = [integer ::]
+    allocate(res % p, source=input3d_layer(layer_shape))
+    res % initialized = .true.
+  end function input3d
 
   pure module function maxpool2d(pool_size, stride) result(res)
     integer, intent(in) :: pool_size

--- a/src/nf_network_submodule.f90
+++ b/src/nf_network_submodule.f90
@@ -30,11 +30,10 @@ contains
     !TODO Ensure that the layers are in allowed sequence:
     !TODO   input1d -> dense
     !TODO   dense -> dense
-    !TODO   input3d -> conv2d
-    !TODO   conv2d -> conv2d
-    !TODO   conv2d -> maxpool2d
-    !TODO   maxpool2d -> conv2d
-    !TODO   conv2d -> flatten
+    !TODO   input3d -> conv2d, maxpool2d, flatten
+    !TODO   conv2d -> conv2d, maxpool2d, flatten
+    !TODO   maxpool2d -> conv2d, maxpool2d, flatten
+    !TODO   flatten -> dense
 
     res % layers = layers
 

--- a/test/test_flatten_layer.f90
+++ b/test/test_flatten_layer.f90
@@ -1,0 +1,32 @@
+program test_flatten_layer
+
+  use iso_fortran_env, only: stderr => error_unit
+  use nf, only: flatten, layer
+  use nf_flatten_layer, only: flatten_layer
+
+  implicit none
+
+  type(layer) :: test_layer
+  real, allocatable :: output(:)
+  logical :: ok = .true.
+
+  test_layer = flatten()
+
+  if (.not. test_layer % name == 'flatten') then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer has its name set correctly.. failed'
+  end if
+
+  if (test_layer % initialized) then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer is not initialized yet.. failed'
+  end if
+
+  if (ok) then
+    print '(a)', 'test_flatten_layer: All tests passed.'
+  else
+    write(stderr, '(a)') 'test_flatten_layer: One or more tests failed.'
+    stop 1
+  end if
+
+end program test_flatten_layer


### PR DESCRIPTION
This PR introduces a flatten layer to chain layers with 3-d output with layers with 1-d input.

TODO:

* [ ] test the backward pass
* [ ] test chaining `conv2d` -> `flatten` -> `dense`

Closes #68.