### PR TITLE
Implement the reshape layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.gz
 *.o
 *.mod
+*.smod
 *.dat
 *.h5
-build
-doc
+/build
+/doc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(neural
   src/nf/nf_parallel_submodule.f90
   src/nf/nf_random.f90
   src/nf/nf_random_submodule.f90
+  src/nf/nf_reshape_layer.f90
+  src/nf/nf_reshape_layer_submodule.f90
   src/nf/io/nf_io_binary.f90
   src/nf/io/nf_io_binary_submodule.f90
   src/nf/io/nf_io_hdf5.f90

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 
 * Dense, fully connected neural layers
 * Convolutional and max-pooling layers (experimental, forward propagation only)
-* Flatten layers (forward and backward pass)
+* Flatten and reshape layers (forward and backward passes)
 * Loading dense and convolutional models from Keras h5 files
 * Stochastic and mini-batch gradient descent for back-propagation
 * Data-based parallelism
@@ -29,10 +29,11 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 | Layer type | Constructor name | Supported input layers | Rank of output array | Forward pass | Backward pass |
 |------------|------------------|------------------------|----------------------|--------------|---------------|
 | Input (1-d and 3-d) | `input` | n/a | 1, 3 | n/a | n/a |
-| Dense (fully-connected) | `dense` | `input` (1-d) | 1 | ✅ | ✅ |
-| Convolutional (2-d) | `conv2d` | `input` (3-d), `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
-| Max-pooling (2-d) | `maxpool2d` | `input` (3-d), `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
-| Flatten | `flatten` | `input` (3-d), `conv2d`, `maxpool2d` | 1 | ✅ | ✅ |
+| Dense (fully-connected) | `dense` | `input1d` | 1 | ✅ | ✅ |
+| Convolutional (2-d) | `conv2d` | `input3d`, `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
+| Max-pooling (2-d) | `maxpool2d` | `input3d`, `conv2d`, `maxpool2d` | 3 | ✅ | ❌ |
+| Flatten | `flatten` | `input3d`, `conv2d`, `maxpool2d` | 1 | ✅ | ✅ |
+| Reshape (1-d to 3-d) | `reshape` | `input1d`, `dense`, `flatten` | 3 | ✅ | ✅ |
 
 ## Getting started
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "neural-fortran"
-version = "0.7.0"
+version = "0.8.0"
 license = "MIT"
 author = "Milan Curcic"
 maintainer = "milancurcic@hey.com"

--- a/src/nf.f90
+++ b/src/nf.f90
@@ -3,7 +3,7 @@ module nf
   use nf_datasets_mnist, only: label_digits, load_mnist
   use nf_layer, only: layer
   use nf_layer_constructors, only: &
-    conv2d, dense, flatten, input, maxpool2d, reshape3d
+    conv2d, dense, flatten, input, maxpool2d, reshape
   use nf_network, only: network
   use nf_optimizers, only: sgd
 end module nf

--- a/src/nf.f90
+++ b/src/nf.f90
@@ -2,7 +2,8 @@ module nf
   !! User API: everything an application needs to reference directly
   use nf_datasets_mnist, only: label_digits, load_mnist
   use nf_layer, only: layer
-  use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d
+  use nf_layer_constructors, only: &
+    conv2d, dense, flatten, input, maxpool2d, reshape3d
   use nf_network, only: network
   use nf_optimizers, only: sgd
 end module nf

--- a/src/nf/nf_datasets.f90
+++ b/src/nf/nf_datasets.f90
@@ -12,6 +12,7 @@ module nf_datasets
     download_and_unpack, &
     keras_cnn_mnist_url, &
     keras_dense_mnist_url, &
+    keras_reshape_url, &
     mnist_url
 
   character(*), parameter :: keras_snippets_baseurl = &
@@ -22,6 +23,8 @@ module nf_datasets
     keras_snippets_baseurl // '/8892585/keras_cnn_mnist.tar.gz'
   character(*), parameter :: keras_dense_mnist_url = &
     keras_snippets_baseurl // '/8788739/keras_dense_mnist.tar.gz'
+  character(*), parameter :: keras_reshape_url = &
+    keras_snippets_baseurl // '/9667603/keras_reshape.tar.gz'
   character(*), parameter :: mnist_url = &
     neural_fortran_baseurl // '/8498876/mnist.tar.gz'
 

--- a/src/nf/nf_keras.f90
+++ b/src/nf/nf_keras.f90
@@ -29,6 +29,9 @@ module nf_keras
     integer, allocatable :: pool_size(:)
     integer, allocatable :: strides(:)
 
+    ! Reshape
+    integer, allocatable :: target_shape(:)
+
   end type keras_layer
 
   interface

--- a/src/nf/nf_keras_submodule.f90
+++ b/src/nf/nf_keras_submodule.f90
@@ -82,6 +82,13 @@ contains
           res(n) % pool_size = reverse(res(n) % pool_size)
           res(n) % strides = reverse(res(n) % strides)
 
+        case('Reshape')
+          ! Only read target shape
+          call json % get(layer_config_json, &
+            'target_shape',  res(n) % target_shape, found)
+          ! Reverse to account for C -> Fortran order
+          res(n) % target_shape = reverse(res(n) % target_shape)
+
         case default
           error stop 'This Keras layer is not supported'
 

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -24,24 +24,25 @@ module nf_layer
 
   contains
 
-    procedure :: backward
     procedure :: forward
     procedure :: init
     procedure :: print_info
     procedure :: update
 
-    ! Specific output subroutines for different array ranks,
-    ! available via generic `get_output`.
+    ! Specific subroutines for different array ranks
+    procedure, private :: backward_1d
+    procedure, private :: backward_3d
     procedure, private :: get_output_1d
     procedure, private :: get_output_3d
 
+    generic :: backward => backward_1d, backward_3d
     generic :: get_output => get_output_1d, get_output_3d
 
   end type layer
 
-  interface
+  interface backward
 
-    pure module subroutine backward(self, previous, gradient)
+    pure module subroutine backward_1d(self, previous, gradient)
       !! Apply a backward pass on the layer.
       !! This changes the internal state of the layer.
       !! This is normally called internally by the `network % backward`
@@ -52,7 +53,24 @@ module nf_layer
         !! Previous layer instance
       real, intent(in) :: gradient(:)
         !! Array of gradient values from the next layer
-    end subroutine backward
+    end subroutine backward_1d
+
+    pure module subroutine backward_3d(self, previous, gradient)
+      !! Apply a backward pass on the layer.
+      !! This changes the internal state of the layer.
+      !! This is normally called internally by the `network % backward`
+      !! method.
+      class(layer), intent(in out) :: self
+        !! Layer instance
+      class(layer), intent(in) :: previous
+        !! Previous layer instance
+      real, intent(in) :: gradient(:,:,:)
+        !! Array of gradient values from the next layer
+    end subroutine backward_3d
+
+  end interface backward
+
+  interface
 
     pure module subroutine forward(self, input)
       !! Apply a forward pass on the layer.

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -7,7 +7,7 @@ module nf_layer_constructors
   implicit none
 
   private
-  public :: conv2d, dense, flatten, input, maxpool2d
+  public :: conv2d, dense, flatten, input, maxpool2d, reshape3d
 
   interface input
 
@@ -153,6 +153,17 @@ module nf_layer_constructors
       type(layer) :: res
         !! Resulting layer instance
     end function maxpool2d
+
+    pure module function reshape3d(output_shape) result(res)
+      !! Rank-1 to rank-3 reshape layer constructor.
+      !!
+      !! This layer is for connecting rank-1 inputs to conv2d or similar
+      !! layers.
+      integer, intent(in), optional :: output_shape(:)
+        !! Shape of the output
+      type(layer) :: res
+        !! Resulting layer instance
+    end function reshape3d
 
   end interface
 

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -7,7 +7,7 @@ module nf_layer_constructors
   implicit none
 
   private
-  public :: conv2d, dense, flatten, input, maxpool2d, reshape3d
+  public :: conv2d, dense, flatten, input, maxpool2d, reshape
 
   interface input
 
@@ -154,16 +154,16 @@ module nf_layer_constructors
         !! Resulting layer instance
     end function maxpool2d
 
-    pure module function reshape3d(output_shape) result(res)
-      !! Rank-1 to rank-3 reshape layer constructor.
+    pure module function reshape(output_shape) result(res)
+      !! Rank-1 to rank-any reshape layer constructor.
+      !! Currently implemented is only rank-3 for the output of the reshape.
       !!
-      !! This layer is for connecting rank-1 inputs to conv2d or similar
-      !! layers.
-      integer, intent(in), optional :: output_shape(:)
+      !! This layer is for connecting 1-d inputs to conv2d or similar layers.
+      integer, intent(in) :: output_shape(:)
         !! Shape of the output
       type(layer) :: res
         !! Resulting layer instance
-    end function reshape3d
+    end function reshape
 
   end interface
 

--- a/src/nf/nf_layer_constructors_submodule.f90
+++ b/src/nf/nf_layer_constructors_submodule.f90
@@ -7,6 +7,7 @@ submodule(nf_layer_constructors) nf_layer_constructors_submodule
   use nf_input1d_layer, only: input1d_layer
   use nf_input3d_layer, only: input3d_layer
   use nf_maxpool2d_layer, only: maxpool2d_layer
+  use nf_reshape_layer, only: reshape3d_layer
 
   implicit none
 
@@ -108,5 +109,19 @@ contains
     )
 
   end function maxpool2d
+
+  pure module function reshape(output_shape) result(res)
+    integer, intent(in) :: output_shape(:)
+    type(layer) :: res
+
+    res % name = 'reshape'
+
+    if (size(output_shape) == 3) then
+      allocate(res % p, source=reshape3d_layer(output_shape))
+    else
+      error stop 'size(output_shape) of the reshape layer must == 3'
+    end if
+
+  end function reshape
 
 end submodule nf_layer_constructors_submodule

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -6,10 +6,11 @@ submodule(nf_network) nf_network_submodule
   use nf_input1d_layer, only: input1d_layer
   use nf_input3d_layer, only: input3d_layer
   use nf_maxpool2d_layer, only: maxpool2d_layer
+  use nf_reshape_layer, only: reshape3d_layer
   use nf_io_hdf5, only: get_hdf5_dataset
   use nf_keras, only: get_keras_h5_layers, keras_layer
   use nf_layer, only: layer
-  use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d
+  use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
   use nf_loss, only: quadratic_derivative
   use nf_optimizers, only: sgd
   use nf_parallel, only: tile_indices
@@ -117,6 +118,9 @@ contains
             keras_layers(n) % strides(1) &
           )
 
+        case('Reshape')
+          layers(n) = reshape(keras_layers(n) % target_shape)
+
         case default
           error stop 'This Keras layer is not supported'
 
@@ -162,6 +166,10 @@ contains
           continue
 
         type is(maxpool2d_layer)
+          ! Nothing to do
+          continue
+
+        type is(reshape3d_layer)
           ! Nothing to do
           continue
 

--- a/src/nf/nf_reshape_layer.f90
+++ b/src/nf/nf_reshape_layer.f90
@@ -16,7 +16,7 @@ module nf_reshape_layer
     !! Concrete implementation of a reshape layer type
     !! It implements only rank-1 to rank-3 reshaping.
 
-    integer, allocatable :: input_shape(:)
+    integer, allocatable :: input_shape(:), output_shape(:)
     real, allocatable :: output(:,:,:)
 
   contains
@@ -30,7 +30,7 @@ module nf_reshape_layer
   interface reshape3d_layer
     pure module function reshape3d_layer_cons(output_shape) result(res)
       !! This function returns the `reshape_layer` instance.
-      integer, intent(in) :: output_shape(:)
+      integer, intent(in) :: output_shape(3)
         !! The shape of the output
       type(reshape3d_layer) :: res
         !! reshape_layer instance

--- a/src/nf/nf_reshape_layer.f90
+++ b/src/nf/nf_reshape_layer.f90
@@ -1,0 +1,77 @@
+module nf_reshape_layer
+
+  !! This module provides the concrete reshape layer type.
+  !! It is used internally by the layer type.
+  !! It is not intended to be used directly by the user.
+
+  use nf_base_layer, only: base_layer
+
+  implicit none
+
+  private
+  public :: reshape_layer
+
+  type, extends(base_layer) :: reshape_layer
+
+    !! Concrete implementation of a reshape layer type
+    !! It implements only rank-1 to rank-3 reshaping.
+
+    integer :: input_size
+
+    real, allocatable :: output(:,:,:)
+
+  contains
+
+    procedure :: backward
+    procedure :: forward
+    procedure :: init
+
+  end type reshape_layer
+
+  interface reshape_layer
+    elemental module function reshape_layer_cons(output_shape) result(res)
+      !! This function returns the `reshape_layer` instance.
+      integer, intent(in) :: output_shape(:)
+        !! The shape of the output
+      type(reshape_layer) :: res
+        !! reshape_layer instance
+    end function reshape_layer_cons
+  end interface reshape_layer
+
+  interface
+
+    pure module subroutine backward(self, input, gradient)
+      !! Apply the backward gradient descent pass.
+      !! Only weight and bias gradients are updated in this subroutine,
+      !! while the weights and biases themselves are untouched.
+      class(reshape_layer), intent(in out) :: self
+        !! Dense layer instance
+      real, intent(in) :: input(:)
+        !! Input from the previous layer
+      real, intent(in) :: gradient(:,:,:)
+        !! Gradient from the next layer
+    end subroutine backward
+
+    pure module subroutine forward(self, input)
+      !! Propagate forward the layer.
+      !! Calling this subroutine updates the values of a few data components
+      !! of `reshape_layer` that are needed for the backward pass.
+      class(reshape_layer), intent(in out) :: self
+        !! Dense layer instance
+      real, intent(in) :: input(:)
+        !! Input from the previous layer
+    end subroutine forward
+
+    module subroutine init(self, input_shape)
+      !! Initialize the layer data structures.
+      !!
+      !! This is a deferred procedure from the `base_layer` abstract type.
+      class(reshape_layer), intent(in out) :: self
+        !! Dense layer instance
+      integer, intent(in) :: input_shape(:)
+        !! Shape of the input layer
+    end subroutine init
+
+  end interface
+
+end module nf_reshape_layer

--- a/src/nf/nf_reshape_layer.f90
+++ b/src/nf/nf_reshape_layer.f90
@@ -9,15 +9,14 @@ module nf_reshape_layer
   implicit none
 
   private
-  public :: reshape_layer
+  public :: reshape3d_layer
 
-  type, extends(base_layer) :: reshape_layer
+  type, extends(base_layer) :: reshape3d_layer
 
     !! Concrete implementation of a reshape layer type
     !! It implements only rank-1 to rank-3 reshaping.
 
-    integer :: input_size
-
+    integer, allocatable :: input_shape(:)
     real, allocatable :: output(:,:,:)
 
   contains
@@ -26,17 +25,17 @@ module nf_reshape_layer
     procedure :: forward
     procedure :: init
 
-  end type reshape_layer
+  end type reshape3d_layer
 
-  interface reshape_layer
-    elemental module function reshape_layer_cons(output_shape) result(res)
+  interface reshape3d_layer
+    pure module function reshape3d_layer_cons(output_shape) result(res)
       !! This function returns the `reshape_layer` instance.
       integer, intent(in) :: output_shape(:)
         !! The shape of the output
-      type(reshape_layer) :: res
+      type(reshape3d_layer) :: res
         !! reshape_layer instance
-    end function reshape_layer_cons
-  end interface reshape_layer
+    end function reshape3d_layer_cons
+  end interface reshape3d_layer
 
   interface
 
@@ -44,7 +43,7 @@ module nf_reshape_layer
       !! Apply the backward gradient descent pass.
       !! Only weight and bias gradients are updated in this subroutine,
       !! while the weights and biases themselves are untouched.
-      class(reshape_layer), intent(in out) :: self
+      class(reshape3d_layer), intent(in out) :: self
         !! Dense layer instance
       real, intent(in) :: input(:)
         !! Input from the previous layer
@@ -56,7 +55,7 @@ module nf_reshape_layer
       !! Propagate forward the layer.
       !! Calling this subroutine updates the values of a few data components
       !! of `reshape_layer` that are needed for the backward pass.
-      class(reshape_layer), intent(in out) :: self
+      class(reshape3d_layer), intent(in out) :: self
         !! Dense layer instance
       real, intent(in) :: input(:)
         !! Input from the previous layer
@@ -66,7 +65,7 @@ module nf_reshape_layer
       !! Initialize the layer data structures.
       !!
       !! This is a deferred procedure from the `base_layer` abstract type.
-      class(reshape_layer), intent(in out) :: self
+      class(reshape3d_layer), intent(in out) :: self
         !! Dense layer instance
       integer, intent(in) :: input_shape(:)
         !! Shape of the input layer

--- a/src/nf/nf_reshape_layer.f90
+++ b/src/nf/nf_reshape_layer.f90
@@ -16,7 +16,9 @@ module nf_reshape_layer
     !! Concrete implementation of a reshape layer type
     !! It implements only rank-1 to rank-3 reshaping.
 
-    integer, allocatable :: input_shape(:), output_shape(:)
+    integer :: input_shape(1)
+    integer :: output_shape(3)
+    real, allocatable :: gradient(:)
     real, allocatable :: output(:,:,:)
 
   contains
@@ -40,9 +42,8 @@ module nf_reshape_layer
   interface
 
     pure module subroutine backward(self, input, gradient)
-      !! Apply the backward gradient descent pass.
-      !! Only weight and bias gradients are updated in this subroutine,
-      !! while the weights and biases themselves are untouched.
+      !! Apply the backward pass for the reshape3d layer.
+      !! This is just flattening to a rank-1 array.
       class(reshape3d_layer), intent(in out) :: self
         !! Dense layer instance
       real, intent(in) :: input(:)
@@ -52,9 +53,8 @@ module nf_reshape_layer
     end subroutine backward
 
     pure module subroutine forward(self, input)
-      !! Propagate forward the layer.
-      !! Calling this subroutine updates the values of a few data components
-      !! of `reshape_layer` that are needed for the backward pass.
+      !! Apply the forward pass for the reshape3d layer.
+      !! This is just a reshape from rank-1 to rank-3 array.
       class(reshape3d_layer), intent(in out) :: self
         !! Dense layer instance
       real, intent(in) :: input(:)

--- a/src/nf/nf_reshape_layer_submodule.f90
+++ b/src/nf/nf_reshape_layer_submodule.f90
@@ -1,0 +1,46 @@
+submodule(nf_reshape_layer) nf_reshape_layer_submodule
+
+  use nf_base_layer, only: base_layer
+
+  implicit none
+
+contains
+
+  pure module function reshape3d_layer_cons(output_shape) result(res)
+    integer, intent(in) :: output_shape(3)
+    type(reshape3d_layer) :: res
+    res % output_shape = output_shape
+  end function reshape3d_layer_cons
+
+
+  pure module subroutine backward(self, input, gradient)
+    class(reshape3d_layer), intent(in out) :: self
+    real, intent(in) :: input(:)
+    real, intent(in) :: gradient(:,:,:)
+    error stop 'Not implemented'
+  end subroutine backward
+
+
+  pure module subroutine forward(self, input)
+    class(reshape3d_layer), intent(in out) :: self
+    real, intent(in) :: input(:)
+    error stop 'Not implemented'
+  end subroutine forward
+
+
+  module subroutine init(self, input_shape)
+    class(reshape3d_layer), intent(in out) :: self
+    integer, intent(in) :: input_shape(:)
+
+    self % input_shape = input_shape
+
+    allocate(self % output( &
+      self % output_shape(1), &
+      self % output_shape(2), &
+      self % output_shape(3) &
+      ))
+    self % output = 0
+
+  end subroutine init
+
+end submodule nf_reshape_layer_submodule

--- a/src/nf/nf_reshape_layer_submodule.f90
+++ b/src/nf/nf_reshape_layer_submodule.f90
@@ -17,14 +17,16 @@ contains
     class(reshape3d_layer), intent(in out) :: self
     real, intent(in) :: input(:)
     real, intent(in) :: gradient(:,:,:)
-    error stop 'Not implemented'
+    ! The `input` dummy argument is not used but nevertheless declared
+    ! because the abstract type requires it.
+    self % gradient = pack(gradient, .true.)
   end subroutine backward
 
 
   pure module subroutine forward(self, input)
     class(reshape3d_layer), intent(in out) :: self
     real, intent(in) :: input(:)
-    error stop 'Not implemented'
+    self % output = reshape(input, self % output_shape)
   end subroutine forward
 
 
@@ -33,6 +35,9 @@ contains
     integer, intent(in) :: input_shape(:)
 
     self % input_shape = input_shape
+
+    allocate(self % gradient(input_shape(1)))
+    self % gradient = 0
 
     allocate(self % output( &
       self % output_shape(1), &

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(execid
   conv2d_layer
   maxpool2d_layer
   flatten_layer
+  reshape_layer
   dense_network
   io_hdf5
   keras_read_model

--- a/test/test_reshape_layer.f90
+++ b/test/test_reshape_layer.f90
@@ -1,0 +1,31 @@
+program test_reshape_layer
+
+  use iso_fortran_env, only: stderr => error_unit
+  use nf, only: input, network, reshape3d
+
+  implicit none
+
+  type(network) :: net
+  real, allocatable :: sample_input(:), output(:,:,:)
+  integer, parameter :: output_shape(3) = [3, 32, 32]
+  integer, parameter :: input_size = product(output_shape)
+  logical :: ok = .true.
+
+  net = network([ &
+    input(input_size), &
+    reshape3d(output_shape) &
+  ])
+
+  if (.not. size(net % layers) == 3) then
+    write(stderr, '(a)') 'the network should have 3 layers.. failed'
+    ok = .false.
+  end if
+
+  if (ok) then
+    print '(a)', 'test_reshape_layer: All tests passed.'
+  else
+    write(stderr, '(a)') 'test_reshape_layer: One or more tests failed.'
+    stop 1
+  end if
+
+end program test_reshape_layer

--- a/test/test_reshape_layer.f90
+++ b/test/test_reshape_layer.f90
@@ -1,7 +1,7 @@
 program test_reshape_layer
 
   use iso_fortran_env, only: stderr => error_unit
-  use nf, only: input, network, reshape3d
+  use nf, only: input, network, reshape
 
   implicit none
 
@@ -13,11 +13,11 @@ program test_reshape_layer
 
   net = network([ &
     input(input_size), &
-    reshape3d(output_shape) &
+    reshape(output_shape) &
   ])
 
-  if (.not. size(net % layers) == 3) then
-    write(stderr, '(a)') 'the network should have 3 layers.. failed'
+  if (.not. size(net % layers) == 2) then
+    write(stderr, '(a)') 'the network should have 2 layers.. failed'
     ok = .false.
   end if
 

--- a/test/test_reshape_layer.f90
+++ b/test/test_reshape_layer.f90
@@ -2,6 +2,7 @@ program test_reshape_layer
 
   use iso_fortran_env, only: stderr => error_unit
   use nf, only: input, network, reshape_layer => reshape
+  use nf_datasets, only: download_and_unpack, keras_reshape_url
 
   implicit none
 
@@ -9,6 +10,8 @@ program test_reshape_layer
   real, allocatable :: sample_input(:), output(:,:,:)
   integer, parameter :: output_shape(3) = [3, 32, 32]
   integer, parameter :: input_size = product(output_shape)
+  character(*), parameter :: keras_reshape_path = 'keras_reshape.h5'
+  logical :: file_exists
   logical :: ok = .true.
 
   ! Create the network
@@ -37,6 +40,31 @@ program test_reshape_layer
 
   if (.not. all(reshape(sample_input, output_shape) == output)) then
     write(stderr, '(a)') 'the reshape layer produces expected output values.. failed'
+    ok = .false.
+  end if
+
+  ! Now test reading the reshape layer from a Keras h5 model.
+  inquire(file=keras_reshape_path, exist=file_exists)
+  if (.not. file_exists) call download_and_unpack(keras_reshape_url)
+
+  net = network(keras_reshape_path)
+
+  if (.not. size(net % layers) == 2) then
+    write(stderr, '(a)') 'the reshape network from Keras has the correct size.. failed'
+    ok = .false.
+  end if
+
+  if (.not. net % layers(2) % name == 'reshape') then
+    write(stderr, '(a)') 'the 2nd layer of the reshape network from Keras is a reshape layer.. failed'
+    ok = .false.
+  end if
+
+  ! Test that the output shape checks out
+  call net % layers(1) % get_output(sample_input)
+  call net % layers(2) % get_output(output)
+
+  if (.not. all(shape(output) == [1, 28, 28])) then
+    write(stderr, '(a)') 'the target shape of the reshape layer is correct.. failed'
     ok = .false.
   end if
 


### PR DESCRIPTION
This PR implements the reshape layer, only rank 1 to rank 3 for the time being.

* [x] Layer implementation + forward and backward passes
* [x] Tests
* [x] Update CMake build
* [x] Integrate with the Keras HDF5 reader
* [x] ~Add an example program~ (example use is shown in the test; tackle full example (e.g. CNN from 1-d input data in a separate PR).

Closes #88 