### PR TITLE
fixed cmake build & added get_num_params() 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ include(cmake/json.cmake)
 # library to archive (libneural.a)
 add_library(neural
   src/nf.f90
-  src/nf/nf_activation.f90
+  src/nf/nf_activation_1d.f90
+  src/nf/nf_activation_3d.f90
   src/nf/nf_base_layer.f90
-  src/nf/nf_base_layer_submodule.f90
   src/nf/nf_conv2d_layer.f90
   src/nf/nf_conv2d_layer_submodule.f90
   src/nf/nf_datasets.f90

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -3,6 +3,7 @@ foreach(execid
   cnn_from_keras
   dense_mnist
   dense_from_keras
+  params
   simple
   sine
 )

--- a/example/params.f90
+++ b/example/params.f90
@@ -48,4 +48,8 @@ program params
    nparam = net % get_num_params()
    print '("#parameters: ", i0)', nparam
 
+   if (allocated(parameters)) then
+      print *,'parameters:', parameters
+   end if
+
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -8,6 +8,7 @@ program params
    integer, parameter :: test_size = 30
    real :: xtest(test_size), ytest(test_size), ypred(test_size)
    integer :: i, n, nparam
+   real, allocatable :: parameters(:)
 
    print '("Sine training")'
    print '(60("="))'

--- a/example/params.f90
+++ b/example/params.f90
@@ -46,11 +46,12 @@ program params
    print *,''
 
    nparam = net % get_num_params()
-   print '("#parameters: ", i0)', nparam
+   print '("get_num_params = ", i0)', nparam
 
    call net % get_parameters(parameters)
 
    if (allocated(parameters)) then
+      print '("size(parameters) = ", i0)', size(parameters)
       print *,'parameters:', parameters
    end if
 

--- a/example/params.f90
+++ b/example/params.f90
@@ -65,6 +65,9 @@ program params
 
     call net2%print_info()
 
+    ! copy the parameters from net to net2
+    call net2%set_parameters(parameters)
+
     ypred = [(net%predict([xtest(i)]), i=1, test_size)]
     print *, 'Original network test output:'
     print *, ypred

--- a/example/params.f90
+++ b/example/params.f90
@@ -16,7 +16,7 @@ program params
    net = network([ &
       input(1), &
       dense(5), &
-      dense(3), &
+      dense(3), & ! only for testing purposes (this layer is not really needed to solve this problem)
       dense(1) &
       ])
 

--- a/example/params.f90
+++ b/example/params.f90
@@ -66,11 +66,11 @@ program params
     call net2%print_info()
 
     ypred = [(net%predict([xtest(i)]), i=1, test_size)]
-    print *, 'Before:'
+    print *, 'Original network test output:'
     print *, ypred
 
     ypred = [(net2%predict([xtest(i)]), i=1, test_size)]
-    print *, 'After:'
+    print *, 'Cloned network test output:'
     print *, ypred
 
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -15,6 +15,7 @@ program params
    net = network([ &
       input(1), &
       dense(5), &
+      dense(3), &
       dense(1) &
       ])
 

--- a/example/params.f90
+++ b/example/params.f90
@@ -1,0 +1,47 @@
+program params
+   use nf, only: dense, input, network
+   implicit none
+   type(network) :: net
+   real :: x(1), y(1)
+   real, parameter :: pi = 4 * atan(1.)
+   integer, parameter :: num_iterations = 100000
+   integer, parameter :: test_size = 30
+   real :: xtest(test_size), ytest(test_size), ypred(test_size)
+   integer :: i, n
+
+   print '("Sine training")'
+   print '(60("="))'
+
+   net = network([ &
+      input(1), &
+      dense(5), &
+      dense(1) &
+      ])
+
+   call net % print_info()
+
+   xtest = [((i - 1) * 2 * pi / test_size, i = 1, test_size)]
+   ytest = (sin(xtest) + 1) / 2
+
+   do n = 0, num_iterations
+
+      call random_number(x)
+      x = x * 2 * pi
+      y = (sin(x) + 1) / 2
+
+      call net % forward(x)
+      call net % backward(y)
+      call net % update(1.)
+
+      if (mod(n, 10000) == 0) then
+         ypred = [(net % predict([xtest(i)]), i = 1, test_size)]
+         print '(i0,1x,f9.6)', n, sum((ypred - ytest)**2) / size(ypred)
+      end if
+
+   end do
+
+   print *,''
+   print '("Extract parameters")'
+   print *,''
+
+end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -65,4 +65,12 @@ program params
 
     call net2%print_info()
 
+    ypred = [(net%predict([xtest(i)]), i=1, test_size)]
+    print *, 'Before:'
+    print *, ypred
+
+    ypred = [(net2%predict([xtest(i)]), i=1, test_size)]
+    print *, 'After:'
+    print *, ypred
+
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -48,6 +48,8 @@ program params
    nparam = net % get_num_params()
    print '("#parameters: ", i0)', nparam
 
+   call net % get_parameters(parameters)
+
    if (allocated(parameters)) then
       print *,'parameters:', parameters
    end if

--- a/example/params.f90
+++ b/example/params.f90
@@ -1,7 +1,7 @@
 program params
     use nf, only: dense, input, network
     implicit none
-    type(network) :: net
+    type(network) :: net, net2
     real :: x(1), y(1)
     real, parameter :: pi = 4*atan(1.)
     integer, parameter :: num_iterations = 100000
@@ -55,5 +55,14 @@ program params
         print '("size(parameters) = ", i0)', size(parameters)
         print *, 'parameters:', parameters
     end if
+
+    net2 = network([ &
+                   input(1), &
+                   dense(5), &
+                   dense(3), & ! only for testing purposes (this layer is not really needed to solve this problem)
+                   dense(1) &
+                   ])
+
+    call net2%print_info()
 
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -45,6 +45,6 @@ program params
    print *,''
 
    nparam = net % get_num_params()
-   print '(i0," #parameters")', nparam
+   print '("#parameters: ", i0)', nparam
 
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -1,59 +1,59 @@
 program params
-   use nf, only: dense, input, network
-   implicit none
-   type(network) :: net
-   real :: x(1), y(1)
-   real, parameter :: pi = 4 * atan(1.)
-   integer, parameter :: num_iterations = 100000
-   integer, parameter :: test_size = 30
-   real :: xtest(test_size), ytest(test_size), ypred(test_size)
-   integer :: i, n, nparam
-   real, allocatable :: parameters(:)
+    use nf, only: dense, input, network
+    implicit none
+    type(network) :: net
+    real :: x(1), y(1)
+    real, parameter :: pi = 4*atan(1.)
+    integer, parameter :: num_iterations = 100000
+    integer, parameter :: test_size = 30
+    real :: xtest(test_size), ytest(test_size), ypred(test_size)
+    integer :: i, n, nparam
+    real, allocatable :: parameters(:)
 
-   print '("Sine training")'
-   print '(60("="))'
+    print '("Sine training")'
+    print '(60("="))'
 
-   net = network([ &
-      input(1), &
-      dense(5), &
-      dense(3), & ! only for testing purposes (this layer is not really needed to solve this problem)
-      dense(1) &
-      ])
+    net = network([ &
+                  input(1), &
+                  dense(5), &
+                  dense(3), & ! only for testing purposes (this layer is not really needed to solve this problem)
+                  dense(1) &
+                  ])
 
-   call net % print_info()
+    call net%print_info()
 
-   xtest = [((i - 1) * 2 * pi / test_size, i = 1, test_size)]
-   ytest = (sin(xtest) + 1) / 2
+    xtest = [((i - 1)*2*pi/test_size, i=1, test_size)]
+    ytest = (sin(xtest) + 1)/2
 
-   do n = 0, num_iterations
+    do n = 0, num_iterations
 
-      call random_number(x)
-      x = x * 2 * pi
-      y = (sin(x) + 1) / 2
+        call random_number(x)
+        x = x*2*pi
+        y = (sin(x) + 1)/2
 
-      call net % forward(x)
-      call net % backward(y)
-      call net % update(1.)
+        call net%forward(x)
+        call net%backward(y)
+        call net%update(1.)
 
-      if (mod(n, 10000) == 0) then
-         ypred = [(net % predict([xtest(i)]), i = 1, test_size)]
-         print '(i0,1x,f9.6)', n, sum((ypred - ytest)**2) / size(ypred)
-      end if
+        if (mod(n, 10000) == 0) then
+            ypred = [(net%predict([xtest(i)]), i=1, test_size)]
+            print '(i0,1x,f9.6)', n, sum((ypred - ytest)**2)/size(ypred)
+        end if
 
-   end do
+    end do
 
-   print *,''
-   print '("Extract parameters")'
-   print *,''
+    print *, ''
+    print '("Extract parameters")'
+    print *, ''
 
-   nparam = net % get_num_params()
-   print '("get_num_params = ", i0)', nparam
+    nparam = net%get_num_params()
+    print '("get_num_params = ", i0)', nparam
 
-   call net % get_parameters(parameters)
+    call net%get_parameters(parameters)
 
-   if (allocated(parameters)) then
-      print '("size(parameters) = ", i0)', size(parameters)
-      print *,'parameters:', parameters
-   end if
+    if (allocated(parameters)) then
+        print '("size(parameters) = ", i0)', size(parameters)
+        print *, 'parameters:', parameters
+    end if
 
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -7,7 +7,7 @@ program params
    integer, parameter :: num_iterations = 100000
    integer, parameter :: test_size = 30
    real :: xtest(test_size), ytest(test_size), ypred(test_size)
-   integer :: i, n
+   integer :: i, n, nparam
 
    print '("Sine training")'
    print '(60("="))'
@@ -43,5 +43,8 @@ program params
    print *,''
    print '("Extract parameters")'
    print *,''
+
+   nparam = net % get_num_params()
+   print '(i0," #parameters")', nparam
 
 end program params

--- a/example/params.f90
+++ b/example/params.f90
@@ -16,6 +16,7 @@ program params
    net = network([ &
       input(1), &
       dense(5), &
+      dense(3), &
       dense(1) &
       ])
 

--- a/example/params.f90
+++ b/example/params.f90
@@ -15,7 +15,6 @@ program params
    net = network([ &
       input(1), &
       dense(5), &
-      dense(3), &
       dense(1) &
       ])
 

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -92,7 +92,7 @@ module nf_conv2d_layer
          !! Number of parameters
       end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+      module subroutine get_parameters(self, params)
          !! Get the parameters of the layer.
          class(conv2d_layer), intent(in) :: self
          !! A `conv2d_layer` instance

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -36,6 +36,7 @@ module nf_conv2d_layer
       procedure :: init
       procedure :: forward
       procedure :: get_num_params
+      procedure :: get_parameters
       procedure :: backward
       procedure :: set_activation
       procedure :: update
@@ -90,6 +91,14 @@ module nf_conv2d_layer
          integer :: num_params
          !! Number of parameters
       end function get_num_params
+
+      pure module subroutine get_parameters(self, params)
+         !! Get the parameters of the layer.
+         class(conv2d_layer), intent(in) :: self
+         !! A `conv2d_layer` instance
+         real, allocatable, intent(inout) :: params(:)
+         !! Parameters
+      end subroutine get_parameters
 
       elemental module subroutine set_activation(self, activation)
          !! Set the activation functions.

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -83,11 +83,11 @@ module nf_conv2d_layer
          !! Gradient (next layer)
       end subroutine backward
 
-      pure module function get_num_params(self) result(res)
+      pure module function get_num_params(self) result(num_params)
          !! Get the number of parameters in the layer.
          class(conv2d_layer), intent(in) :: self
          !! A `conv2d_layer` instance
-         integer :: res
+         integer :: num_params
          !! Number of parameters
       end function get_num_params
 

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -92,7 +92,7 @@ module nf_conv2d_layer
          !! Number of parameters
       end function get_num_params
 
-      module subroutine get_parameters(self, params)
+      pure module subroutine get_parameters(self, params)
          !! Get the parameters of the layer.
          class(conv2d_layer), intent(in) :: self
          !! A `conv2d_layer` instance

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -1,103 +1,112 @@
 module nf_conv2d_layer
 
-  !! This modules provides a 2-d convolutional `conv2d_layer` type.
+   !! This modules provides a 2-d convolutional `conv2d_layer` type.
 
-  use nf_activation_3d, only: activation_function
-  use nf_base_layer, only: base_layer
-  implicit none
+   use nf_activation_3d, only: activation_function
+   use nf_base_layer, only: base_layer
+   implicit none
 
-  private
-  public :: conv2d_layer
+   private
+   public :: conv2d_layer
 
-  type, extends(base_layer) :: conv2d_layer
+   type, extends(base_layer) :: conv2d_layer
 
-    integer :: width
-    integer :: height
-    integer :: channels
-    integer :: kernel_size
-    integer :: filters
+      integer :: width
+      integer :: height
+      integer :: channels
+      integer :: kernel_size
+      integer :: filters
 
-    real, allocatable :: biases(:) ! size(filters)
-    real, allocatable :: kernel(:,:,:,:) ! filters x channels x window x window
-    real, allocatable :: output(:,:,:) ! filters x output_width * output_height
-    real, allocatable :: z(:,:,:) ! kernel .dot. input + bias
+      real, allocatable :: biases(:) ! size(filters)
+      real, allocatable :: kernel(:,:,:,:) ! filters x channels x window x window
+      real, allocatable :: output(:,:,:) ! filters x output_width * output_height
+      real, allocatable :: z(:,:,:) ! kernel .dot. input + bias
 
-    real, allocatable :: dw(:,:,:,:) ! weight (kernel) gradients
-    real, allocatable :: db(:) ! bias gradients
-    real, allocatable :: gradient(:,:,:)
+      real, allocatable :: dw(:,:,:,:) ! weight (kernel) gradients
+      real, allocatable :: db(:) ! bias gradients
+      real, allocatable :: gradient(:,:,:)
 
-    procedure(activation_function), pointer, nopass :: &
-      activation => null()
-    procedure(activation_function), pointer, nopass :: &
-      activation_prime => null()
+      procedure(activation_function), pointer, nopass :: &
+         activation => null()
+      procedure(activation_function), pointer, nopass :: &
+         activation_prime => null()
 
-  contains
+   contains
 
-    procedure :: init
-    procedure :: forward
-    procedure :: backward
-    procedure :: set_activation
-    procedure :: update
+      procedure :: init
+      procedure :: forward
+      procedure :: get_num_params
+      procedure :: backward
+      procedure :: set_activation
+      procedure :: update
 
-  end type conv2d_layer
+   end type conv2d_layer
 
-  interface conv2d_layer
-    pure module function conv2d_layer_cons(filters, kernel_size, activation) &
-      result(res)
-      !! `conv2d_layer` constructor function
-      integer, intent(in) :: filters
-      integer, intent(in) :: kernel_size
-      character(*), intent(in) :: activation
-      type(conv2d_layer) :: res
-    end function conv2d_layer_cons
-  end interface conv2d_layer
+   interface conv2d_layer
+      pure module function conv2d_layer_cons(filters, kernel_size, activation) &
+         result(res)
+         !! `conv2d_layer` constructor function
+         integer, intent(in) :: filters
+         integer, intent(in) :: kernel_size
+         character(*), intent(in) :: activation
+         type(conv2d_layer) :: res
+      end function conv2d_layer_cons
+   end interface conv2d_layer
 
-  interface
+   interface
 
-    module subroutine init(self, input_shape)
-      !! Initialize the layer data structures.
-      !!
-      !! This is a deferred procedure from the `base_layer` abstract type.
-      class(conv2d_layer), intent(in out) :: self
-        !! A `conv2d_layer` instance
-      integer, intent(in) :: input_shape(:)
-        !! Input layer dimensions
-    end subroutine init
+      module subroutine init(self, input_shape)
+         !! Initialize the layer data structures.
+         !!
+         !! This is a deferred procedure from the `base_layer` abstract type.
+         class(conv2d_layer), intent(in out) :: self
+         !! A `conv2d_layer` instance
+         integer, intent(in) :: input_shape(:)
+         !! Input layer dimensions
+      end subroutine init
 
-    pure module subroutine forward(self, input)
-      !! Apply a forward pass on the `conv2d` layer.
-      class(conv2d_layer), intent(in out) :: self
-        !! A `conv2d_layer` instance
-      real, intent(in) :: input(:,:,:)
-        !! Input data
-    end subroutine forward
+      pure module subroutine forward(self, input)
+         !! Apply a forward pass on the `conv2d` layer.
+         class(conv2d_layer), intent(in out) :: self
+         !! A `conv2d_layer` instance
+         real, intent(in) :: input(:,:,:)
+         !! Input data
+      end subroutine forward
 
-    pure module subroutine backward(self, input, gradient)
-      !! Apply a backward pass on the `conv2d` layer.
-      class(conv2d_layer), intent(in out) :: self
-        !! A `conv2d_layer` instance
-      real, intent(in) :: input(:,:,:)
-        !! Input data (previous layer)
-      real, intent(in) :: gradient(:,:,:)
-        !! Gradient (next layer)
-    end subroutine backward
+      pure module subroutine backward(self, input, gradient)
+         !! Apply a backward pass on the `conv2d` layer.
+         class(conv2d_layer), intent(in out) :: self
+         !! A `conv2d_layer` instance
+         real, intent(in) :: input(:,:,:)
+         !! Input data (previous layer)
+         real, intent(in) :: gradient(:,:,:)
+         !! Gradient (next layer)
+      end subroutine backward
 
-    elemental module subroutine set_activation(self, activation)
-    !! Set the activation functions.
-    class(conv2d_layer), intent(in out) :: self
-      !! Layer instance
-    character(*), intent(in) :: activation
-      !! String with the activation function name
-    end subroutine set_activation
+      pure module function get_num_params(self) result(res)
+         !! Get the number of parameters in the layer.
+         class(conv2d_layer), intent(in) :: self
+         !! A `conv2d_layer` instance
+         integer :: res
+         !! Number of parameters
+      end function get_num_params
 
-    module subroutine update(self, learning_rate)
-      !! Update the weights and biases.
-      class(conv2d_layer), intent(in out) :: self
-        !! Dense layer instance
-      real, intent(in) :: learning_rate
-        !! Learning rate (must be > 0)
-    end subroutine update
+      elemental module subroutine set_activation(self, activation)
+         !! Set the activation functions.
+         class(conv2d_layer), intent(in out) :: self
+         !! Layer instance
+         character(*), intent(in) :: activation
+         !! String with the activation function name
+      end subroutine set_activation
 
-  end interface
+      module subroutine update(self, learning_rate)
+         !! Update the weights and biases.
+         class(conv2d_layer), intent(in out) :: self
+         !! Dense layer instance
+         real, intent(in) :: learning_rate
+         !! Learning rate (must be > 0)
+      end subroutine update
+
+   end interface
 
 end module nf_conv2d_layer

--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -2,120 +2,131 @@ module nf_conv2d_layer
 
    !! This modules provides a 2-d convolutional `conv2d_layer` type.
 
-   use nf_activation_3d, only: activation_function
-   use nf_base_layer, only: base_layer
-   implicit none
+    use nf_activation_3d, only: activation_function
+    use nf_base_layer, only: base_layer
+    implicit none
 
-   private
-   public :: conv2d_layer
+    private
+    public :: conv2d_layer
 
-   type, extends(base_layer) :: conv2d_layer
+    type, extends(base_layer) :: conv2d_layer
 
-      integer :: width
-      integer :: height
-      integer :: channels
-      integer :: kernel_size
-      integer :: filters
+        integer :: width
+        integer :: height
+        integer :: channels
+        integer :: kernel_size
+        integer :: filters
 
-      real, allocatable :: biases(:) ! size(filters)
-      real, allocatable :: kernel(:,:,:,:) ! filters x channels x window x window
-      real, allocatable :: output(:,:,:) ! filters x output_width * output_height
-      real, allocatable :: z(:,:,:) ! kernel .dot. input + bias
+        real, allocatable :: biases(:) ! size(filters)
+        real, allocatable :: kernel(:, :, :, :) ! filters x channels x window x window
+        real, allocatable :: output(:, :, :) ! filters x output_width * output_height
+        real, allocatable :: z(:, :, :) ! kernel .dot. input + bias
 
-      real, allocatable :: dw(:,:,:,:) ! weight (kernel) gradients
-      real, allocatable :: db(:) ! bias gradients
-      real, allocatable :: gradient(:,:,:)
+        real, allocatable :: dw(:, :, :, :) ! weight (kernel) gradients
+        real, allocatable :: db(:) ! bias gradients
+        real, allocatable :: gradient(:, :, :)
 
-      procedure(activation_function), pointer, nopass :: &
-         activation => null()
-      procedure(activation_function), pointer, nopass :: &
-         activation_prime => null()
+        procedure(activation_function), pointer, nopass :: &
+            activation => null()
+        procedure(activation_function), pointer, nopass :: &
+            activation_prime => null()
 
-   contains
+    contains
 
-      procedure :: init
-      procedure :: forward
-      procedure :: get_num_params
-      procedure :: get_parameters
-      procedure :: backward
-      procedure :: set_activation
-      procedure :: update
+        procedure :: init
+        procedure :: forward
+        procedure :: get_num_params
+        procedure :: get_parameters
+        procedure :: set_parameters
+        procedure :: backward
+        procedure :: set_activation
+        procedure :: update
 
-   end type conv2d_layer
+    end type conv2d_layer
 
-   interface conv2d_layer
-      pure module function conv2d_layer_cons(filters, kernel_size, activation) &
-         result(res)
+    interface conv2d_layer
+        pure module function conv2d_layer_cons(filters, kernel_size, activation) &
+            result(res)
          !! `conv2d_layer` constructor function
-         integer, intent(in) :: filters
-         integer, intent(in) :: kernel_size
-         character(*), intent(in) :: activation
-         type(conv2d_layer) :: res
-      end function conv2d_layer_cons
-   end interface conv2d_layer
+            integer, intent(in) :: filters
+            integer, intent(in) :: kernel_size
+            character(*), intent(in) :: activation
+            type(conv2d_layer) :: res
+        end function conv2d_layer_cons
+    end interface conv2d_layer
 
-   interface
+    interface
 
-      module subroutine init(self, input_shape)
+        module subroutine init(self, input_shape)
          !! Initialize the layer data structures.
          !!
          !! This is a deferred procedure from the `base_layer` abstract type.
-         class(conv2d_layer), intent(in out) :: self
+            class(conv2d_layer), intent(in out) :: self
          !! A `conv2d_layer` instance
-         integer, intent(in) :: input_shape(:)
+            integer, intent(in) :: input_shape(:)
          !! Input layer dimensions
-      end subroutine init
+        end subroutine init
 
-      pure module subroutine forward(self, input)
+        pure module subroutine forward(self, input)
          !! Apply a forward pass on the `conv2d` layer.
-         class(conv2d_layer), intent(in out) :: self
+            class(conv2d_layer), intent(in out) :: self
          !! A `conv2d_layer` instance
-         real, intent(in) :: input(:,:,:)
+            real, intent(in) :: input(:, :, :)
          !! Input data
-      end subroutine forward
+        end subroutine forward
 
-      pure module subroutine backward(self, input, gradient)
+        pure module subroutine backward(self, input, gradient)
          !! Apply a backward pass on the `conv2d` layer.
-         class(conv2d_layer), intent(in out) :: self
+            class(conv2d_layer), intent(in out) :: self
          !! A `conv2d_layer` instance
-         real, intent(in) :: input(:,:,:)
+            real, intent(in) :: input(:, :, :)
          !! Input data (previous layer)
-         real, intent(in) :: gradient(:,:,:)
+            real, intent(in) :: gradient(:, :, :)
          !! Gradient (next layer)
-      end subroutine backward
+        end subroutine backward
 
-      pure module function get_num_params(self) result(num_params)
+        pure module function get_num_params(self) result(num_params)
          !! Get the number of parameters in the layer.
-         class(conv2d_layer), intent(in) :: self
+            class(conv2d_layer), intent(in) :: self
          !! A `conv2d_layer` instance
-         integer :: num_params
+            integer :: num_params
          !! Number of parameters
-      end function get_num_params
+        end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+        pure module subroutine get_parameters(self, params)
          !! Get the parameters of the layer.
-         class(conv2d_layer), intent(in) :: self
+            class(conv2d_layer), intent(in) :: self
          !! A `conv2d_layer` instance
-         real, allocatable, intent(inout) :: params(:)
+            real, allocatable, intent(inout) :: params(:)
          !! Parameters
-      end subroutine get_parameters
+        end subroutine get_parameters
 
-      elemental module subroutine set_activation(self, activation)
+        module function set_parameters(self, params) result(consumed)
+          !! Set the parameters of the layer.
+            class(conv2d_layer), intent(in out) :: self
+          !! A `conv2d_layer` instance
+            real, intent(in) :: params(:)
+          !! Parameters
+            integer :: consumed
+            !! Number of parameters consumed
+        end function set_parameters
+
+        elemental module subroutine set_activation(self, activation)
          !! Set the activation functions.
-         class(conv2d_layer), intent(in out) :: self
+            class(conv2d_layer), intent(in out) :: self
          !! Layer instance
-         character(*), intent(in) :: activation
+            character(*), intent(in) :: activation
          !! String with the activation function name
-      end subroutine set_activation
+        end subroutine set_activation
 
-      module subroutine update(self, learning_rate)
+        module subroutine update(self, learning_rate)
          !! Update the weights and biases.
-         class(conv2d_layer), intent(in out) :: self
+            class(conv2d_layer), intent(in out) :: self
          !! Dense layer instance
-         real, intent(in) :: learning_rate
+            real, intent(in) :: learning_rate
          !! Learning rate (must be > 0)
-      end subroutine update
+        end subroutine update
 
-   end interface
+    end interface
 
 end module nf_conv2d_layer

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -196,6 +196,18 @@ contains
 
    end function get_num_params
 
+   pure module subroutine get_parameters(self, params)
+      class(conv2d_layer), intent(in) :: self
+      real, allocatable, intent(inout) :: params(:)
+
+      ! first pack the kernel
+      params = [params, pack(self%kernel, .true.)]
+
+      ! then pack the biases
+      params = [params, pack(self % biases, .true.)]
+
+   end subroutine get_parameters
+
    elemental module subroutine set_activation(self, activation)
       class(conv2d_layer), intent(in out) :: self
       character(*), intent(in) :: activation

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -216,6 +216,20 @@ contains
         real, intent(in) :: params(:)
         integer :: consumed
 
+        ! check if the number of parameters is correct
+        if (size(params) .lt. self%get_num_params()) then
+            error stop 'Error: number of parameters does not match'
+        end if
+
+        ! reshape the kernel
+        self%kernel = reshape(params(1:self%filters*self%channels*self%kernel_size*self%kernel_size), &
+                              [self%filters, self%channels, self%kernel_size, self%kernel_size])
+
+        ! reshape the biases
+        self%biases = reshape(params(self%filters*self%channels*self%kernel_size*self%kernel_size + 1:), &
+                              [self%filters])
+
+        consumed = self%get_num_params()
     end function set_parameters
 
     elemental module subroutine set_activation(self, activation)

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -1,294 +1,298 @@
 submodule(nf_conv2d_layer) nf_conv2d_layer_submodule
 
-   use nf_activation_3d, only: activation_function, &
-      elu, elu_prime, &
-      exponential, &
-      gaussian, gaussian_prime, &
-      relu, relu_prime, &
-      sigmoid, sigmoid_prime, &
-      softmax, softmax_prime, &
-      softplus, softplus_prime, &
-      step, step_prime, &
-      tanhf, tanh_prime
-   use nf_random, only: randn
+    use nf_activation_3d, only: activation_function, &
+                                elu, elu_prime, &
+                                exponential, &
+                                gaussian, gaussian_prime, &
+                                relu, relu_prime, &
+                                sigmoid, sigmoid_prime, &
+                                softmax, softmax_prime, &
+                                softplus, softplus_prime, &
+                                step, step_prime, &
+                                tanhf, tanh_prime
+    use nf_random, only: randn
 
-   implicit none
+    implicit none
 
 contains
 
-   pure module function conv2d_layer_cons(filters, kernel_size, activation) result(res)
-      implicit none
-      integer, intent(in) :: filters
-      integer, intent(in) :: kernel_size
-      character(*), intent(in) :: activation
-      type(conv2d_layer) :: res
-      res % kernel_size = kernel_size
-      res % filters = filters
-      call res % set_activation(activation)
-   end function conv2d_layer_cons
+    pure module function conv2d_layer_cons(filters, kernel_size, activation) result(res)
+        implicit none
+        integer, intent(in) :: filters
+        integer, intent(in) :: kernel_size
+        character(*), intent(in) :: activation
+        type(conv2d_layer) :: res
+        res%kernel_size = kernel_size
+        res%filters = filters
+        call res%set_activation(activation)
+    end function conv2d_layer_cons
 
+    module subroutine init(self, input_shape)
+        implicit none
+        class(conv2d_layer), intent(in out) :: self
+        integer, intent(in) :: input_shape(:)
 
-   module subroutine init(self, input_shape)
-      implicit none
-      class(conv2d_layer), intent(in out) :: self
-      integer, intent(in) :: input_shape(:)
+        self%channels = input_shape(1)
+        self%width = input_shape(2) - self%kernel_size + 1
+        self%height = input_shape(3) - self%kernel_size + 1
 
-      self % channels = input_shape(1)
-      self % width = input_shape(2) - self % kernel_size + 1
-      self % height = input_shape(3) - self % kernel_size + 1
+        ! Output of shape filters x width x height
+        allocate (self%output(self%filters, self%width, self%height))
+        self%output = 0
 
-      ! Output of shape filters x width x height
-      allocate(self % output(self % filters, self % width, self % height))
-      self % output = 0
+        ! Kernel of shape filters x channels x width x height
+        allocate (self%kernel(self%filters, self%channels, &
+                              self%kernel_size, self%kernel_size))
 
-      ! Kernel of shape filters x channels x width x height
-      allocate(self % kernel(self % filters, self % channels, &
-         self % kernel_size, self % kernel_size))
+        ! Initialize the kernel with random values with a normal distribution.
+        self%kernel = randn(self%filters, self%channels, &
+                            self%kernel_size, self%kernel_size) &
+                      /self%kernel_size**2 !TODO kernel_width * kernel_height
 
-      ! Initialize the kernel with random values with a normal distribution.
-      self % kernel = randn(self % filters, self % channels, &
-         self % kernel_size, self % kernel_size) &
-         / self % kernel_size**2 !TODO kernel_width * kernel_height
+        allocate (self%biases(self%filters))
+        self%biases = 0
 
-      allocate(self % biases(self % filters))
-      self % biases = 0
+        allocate (self%z, mold=self%output)
+        self%z = 0
 
-      allocate(self % z, mold=self % output)
-      self % z = 0
+        allocate (self%gradient(input_shape(1), input_shape(2), input_shape(3)))
+        self%gradient = 0
 
-      allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
-      self % gradient = 0
+        allocate (self%dw, mold=self%kernel)
+        self%dw = 0
 
-      allocate(self % dw, mold=self % kernel)
-      self % dw = 0
+        allocate (self%db, mold=self%biases)
+        self%db = 0
 
-      allocate(self % db, mold=self % biases)
-      self % db = 0
+    end subroutine init
 
-   end subroutine init
+    pure module subroutine forward(self, input)
+        implicit none
+        class(conv2d_layer), intent(in out) :: self
+        real, intent(in) :: input(:, :, :)
+        integer :: input_width, input_height, input_channels
+        integer :: istart, iend
+        integer :: jstart, jend
+        integer :: i, j, n
+        integer :: iws, iwe, jws, jwe
+        integer :: half_window
 
+        ! Input dimensions are channels x width x height
+        input_channels = size(input, dim=1)
+        input_width = size(input, dim=2)
+        input_height = size(input, dim=3)
 
-   pure module subroutine forward(self, input)
-      implicit none
-      class(conv2d_layer), intent(in out) :: self
-      real, intent(in) :: input(:,:,:)
-      integer :: input_width, input_height, input_channels
-      integer :: istart, iend
-      integer :: jstart, jend
-      integer :: i, j, n
-      integer :: iws, iwe, jws, jwe
-      integer :: half_window
+        ! Half-window is 1 for window size 3; 2 for window size 5; etc.
+        half_window = self%kernel_size/2
 
-      ! Input dimensions are channels x width x height
-      input_channels = size(input, dim=1)
-      input_width = size(input, dim=2)
-      input_height = size(input, dim=3)
+        ! Determine the start and end indices for the width and height dimensions
+        ! of the input that correspond to the center of each window.
+        istart = half_window + 1 ! TODO kernel_width
+        jstart = half_window + 1 ! TODO kernel_height
+        iend = input_width - istart + 1
+        jend = input_height - jstart + 1
 
-      ! Half-window is 1 for window size 3; 2 for window size 5; etc.
-      half_window = self % kernel_size / 2
+        convolution: do concurrent(i=istart:iend, j=jstart:jend)
 
-      ! Determine the start and end indices for the width and height dimensions
-      ! of the input that correspond to the center of each window.
-      istart = half_window + 1 ! TODO kernel_width
-      jstart = half_window + 1 ! TODO kernel_height
-      iend = input_width - istart + 1
-      jend = input_height - jstart + 1
+            ! Start and end indices of the input data on the filter window
+            ! iws and jws are also coincidentally the indices of the output matrix
+            iws = i - half_window ! TODO kernel_width
+            iwe = i + half_window ! TODO kernel_width
+            jws = j - half_window ! TODO kernel_height
+            jwe = j + half_window ! TODO kernel_height
 
-      convolution: do concurrent(i = istart:iend, j = jstart:jend)
+            ! Compute the inner tensor product, sum(w_ij * x_ij), for each filter.
+            do concurrent(n=1:self%filters)
+                self%z(n, iws, jws) = sum(self%kernel(n, :, :, :)*input(:, iws:iwe, jws:jwe))
+            end do
 
-         ! Start and end indices of the input data on the filter window
-         ! iws and jws are also coincidentally the indices of the output matrix
-         iws = i - half_window ! TODO kernel_width
-         iwe = i + half_window ! TODO kernel_width
-         jws = j - half_window ! TODO kernel_height
-         jwe = j + half_window ! TODO kernel_height
+            ! Add bias to the inner product.
+            self%z(:, iws, jws) = self%z(:, iws, jws) + self%biases
 
-         ! Compute the inner tensor product, sum(w_ij * x_ij), for each filter.
-         do concurrent(n = 1:self % filters)
-            self % z(n,iws,jws) = sum(self % kernel(n,:,:,:) * input(:,iws:iwe,jws:jwe))
-         end do
+        end do convolution
 
-         ! Add bias to the inner product.
-         self % z(:,iws,jws) = self % z(:,iws,jws) + self % biases
+        ! Activate
+        self%output = self%activation(self%z)
 
-      end do convolution
+    end subroutine forward
 
-      ! Activate
-      self % output = self % activation(self % z)
+    pure module subroutine backward(self, input, gradient)
+        implicit none
+        class(conv2d_layer), intent(in out) :: self
+        real, intent(in) :: input(:, :, :)
+        real, intent(in) :: gradient(:, :, :)
+        real :: db(self%filters)
+        real :: dw(self%filters, self%channels, self%kernel_size, self%kernel_size)
+        real :: gdz(self%filters, size(input, 2), size(input, 3))
+        integer :: i, j, k, n
+        integer :: input_channels, input_width, input_height
+        integer :: istart, iend
+        integer :: jstart, jend
+        integer :: iws, iwe, jws, jwe
+        integer :: half_window
 
-   end subroutine forward
+        ! Input dimensions are channels x width x height.
+        ! Input frame goes from 1 to input_width and from 1 to input_height.
+        input_channels = size(input, dim=1)
+        input_width = size(input, dim=2)
+        input_height = size(input, dim=3)
 
+        ! Half-window is 1 for window size 3; 2 for window size 5; etc.
+        half_window = self%kernel_size/2
 
-   pure module subroutine backward(self, input, gradient)
-      implicit none
-      class(conv2d_layer), intent(in out) :: self
-      real, intent(in) :: input(:,:,:)
-      real, intent(in) :: gradient(:,:,:)
-      real :: db(self % filters)
-      real :: dw(self % filters, self % channels, self % kernel_size, self % kernel_size)
-      real :: gdz(self % filters, size(input, 2), size(input, 3))
-      integer :: i, j, k, n
-      integer :: input_channels, input_width, input_height
-      integer :: istart, iend
-      integer :: jstart, jend
-      integer :: iws, iwe, jws, jwe
-      integer :: half_window
+        ! Determine the start and end indices for the width and height dimensions
+        ! of the input that correspond to the center of each window.
+        istart = half_window + 1 ! TODO kernel_width
+        jstart = half_window + 1 ! TODO kernel_height
+        iend = input_width - istart + 1
+        jend = input_height - jstart + 1
 
-      ! Input dimensions are channels x width x height.
-      ! Input frame goes from 1 to input_width and from 1 to input_height.
-      input_channels = size(input, dim=1)
-      input_width = size(input, dim=2)
-      input_height = size(input, dim=3)
+        ! z = w .inner. x + b
+        ! gdz = dL/dy * sigma'(z)
+        gdz = 0
+        gdz(:, istart:iend, jstart:jend) = gradient*self%activation_prime(self%z)
 
-      ! Half-window is 1 for window size 3; 2 for window size 5; etc.
-      half_window = self % kernel_size / 2
+        ! dL/db = sum(dL/dy * sigma'(z))
+        do concurrent(n=1:self%filters)
+            db(n) = sum(gdz(n, :, :))
+        end do
 
-      ! Determine the start and end indices for the width and height dimensions
-      ! of the input that correspond to the center of each window.
-      istart = half_window + 1 ! TODO kernel_width
-      jstart = half_window + 1 ! TODO kernel_height
-      iend = input_width - istart + 1
-      jend = input_height - jstart + 1
+        dw = 0
+        self%gradient = 0
+        do concurrent( &
+            n=1:self%filters, &
+            k=1:self%channels, &
+            i=istart:iend, &
+            j=jstart:jend &
+            )
+            ! Start and end indices of the input data on the filter window
+            iws = i - half_window ! TODO kernel_width
+            iwe = i + half_window ! TODO kernel_width
+            jws = j - half_window ! TODO kernel_height
+            jwe = j + half_window ! TODO kernel_height
 
-      ! z = w .inner. x + b
-      ! gdz = dL/dy * sigma'(z)
-      gdz = 0
-      gdz(:,istart:iend,jstart:jend) = gradient * self % activation_prime(self % z)
+            ! dL/dw = sum(dL/dy * sigma'(z) * x)
+            dw(n, k, :, :) = dw(n, k, :, :) + input(k, iws:iwe, jws:jwe)*gdz(n, iws:iwe, jws:jwe)
 
-      ! dL/db = sum(dL/dy * sigma'(z))
-      do concurrent (n = 1:self % filters)
-         db(n) = sum(gdz(n,:,:))
-      end do
+            ! dL/dx = dL/dy * sigma'(z) .inner. w
+            self%gradient(k, i, j) = self%gradient(k, i, j) &
+                                     + sum(gdz(n, iws:iwe, jws:jwe)*self%kernel(n, k, :, :))
 
-      dw = 0
-      self % gradient = 0
-      do concurrent( &
-         n = 1:self % filters, &
-         k = 1:self % channels, &
-         i = istart:iend, &
-         j = jstart:jend &
-         )
-         ! Start and end indices of the input data on the filter window
-         iws = i - half_window ! TODO kernel_width
-         iwe = i + half_window ! TODO kernel_width
-         jws = j - half_window ! TODO kernel_height
-         jwe = j + half_window ! TODO kernel_height
+        end do
 
-         ! dL/dw = sum(dL/dy * sigma'(z) * x)
-         dw(n,k,:,:) = dw(n,k,:,:) + input(k,iws:iwe,jws:jwe) * gdz(n,iws:iwe,jws:jwe)
+        self%dw = self%dw + dw
+        self%db = self%db + db
 
-         ! dL/dx = dL/dy * sigma'(z) .inner. w
-         self % gradient(k,i,j) = self % gradient(k,i,j) &
-            + sum(gdz(n,iws:iwe,jws:jwe) * self % kernel(n,k,:,:))
+    end subroutine backward
 
-      end do
+    pure module function get_num_params(self) result(num_params)
+        class(conv2d_layer), intent(in) :: self
+        integer :: num_params
 
-      self % dw = self % dw + dw
-      self % db = self % db + db
+        num_params = self%filters*self%channels*self%kernel_size*self%kernel_size + self%filters
 
-   end subroutine backward
+    end function get_num_params
 
-   pure module function get_num_params(self) result(num_params)
-      class(conv2d_layer), intent(in) :: self
-      integer :: num_params
+    pure module subroutine get_parameters(self, params)
+        class(conv2d_layer), intent(in) :: self
+        real, allocatable, intent(inout) :: params(:)
 
-      num_params = self % filters * self % channels * self % kernel_size * self % kernel_size + self % filters
+        ! automatic reallocation of params
 
-   end function get_num_params
+        ! first pack the kernel
+        if (allocated(params)) then
+            params = [params, pack(self%kernel, .true.)]
+        else
+            params = pack(self%kernel, .true.)
+        end if
 
-   pure module subroutine get_parameters(self, params)
-      class(conv2d_layer), intent(in) :: self
-      real, allocatable, intent(inout) :: params(:)
+        ! then pack the biases
+        params = [params, pack(self%biases, .true.)]
 
-      ! automatic reallocation of params
+    end subroutine get_parameters
 
-      ! first pack the kernel
-      if (allocated(params)) then
-         params = [params, pack(self%kernel, .true.)]
-      else
-         params = pack(self%kernel, .true.)
-      end if
+    module function set_parameters(self, params) result(consumed)
+        class(conv2d_layer), intent(in out) :: self
+        real, intent(in) :: params(:)
+        integer :: consumed
 
-      ! then pack the biases
-      params = [params, pack(self % biases, .true.)]
+    end function set_parameters
 
-   end subroutine get_parameters
+    elemental module subroutine set_activation(self, activation)
+        class(conv2d_layer), intent(in out) :: self
+        character(*), intent(in) :: activation
 
-   elemental module subroutine set_activation(self, activation)
-      class(conv2d_layer), intent(in out) :: self
-      character(*), intent(in) :: activation
+        select case (trim(activation))
 
-      select case(trim(activation))
+            ! TODO need to figure out how to handle the alpha param
+            !case('elu')
+            !  self % activation => elu
+            !  self % activation_prime => elu_prime
+            !  self % activation_name = 'elu'
 
-         ! TODO need to figure out how to handle the alpha param
-         !case('elu')
-         !  self % activation => elu
-         !  self % activation_prime => elu_prime
-         !  self % activation_name = 'elu'
+        case ('exponential')
+            self%activation => exponential
+            self%activation_prime => exponential
+            self%activation_name = 'exponential'
 
-       case('exponential')
-         self % activation => exponential
-         self % activation_prime => exponential
-         self % activation_name = 'exponential'
+        case ('gaussian')
+            self%activation => gaussian
+            self%activation_prime => gaussian_prime
+            self%activation_name = 'gaussian'
 
-       case('gaussian')
-         self % activation => gaussian
-         self % activation_prime => gaussian_prime
-         self % activation_name = 'gaussian'
+        case ('relu')
+            self%activation => relu
+            self%activation_prime => relu_prime
+            self%activation_name = 'relu'
 
-       case('relu')
-         self % activation => relu
-         self % activation_prime => relu_prime
-         self % activation_name = 'relu'
+        case ('sigmoid')
+            self%activation => sigmoid
+            self%activation_prime => sigmoid_prime
+            self%activation_name = 'sigmoid'
 
-       case('sigmoid')
-         self % activation => sigmoid
-         self % activation_prime => sigmoid_prime
-         self % activation_name = 'sigmoid'
+        case ('softmax')
+            self%activation => softmax
+            self%activation_prime => softmax_prime
+            self%activation_name = 'softmax'
 
-       case('softmax')
-         self % activation => softmax
-         self % activation_prime => softmax_prime
-         self % activation_name = 'softmax'
+        case ('softplus')
+            self%activation => softplus
+            self%activation_prime => softplus_prime
+            self%activation_name = 'softplus'
 
-       case('softplus')
-         self % activation => softplus
-         self % activation_prime => softplus_prime
-         self % activation_name = 'softplus'
+        case ('step')
+            self%activation => step
+            self%activation_prime => step_prime
+            self%activation_name = 'step'
 
-       case('step')
-         self % activation => step
-         self % activation_prime => step_prime
-         self % activation_name = 'step'
+        case ('tanh')
+            self%activation => tanhf
+            self%activation_prime => tanh_prime
+            self%activation_name = 'tanh'
 
-       case('tanh')
-         self % activation => tanhf
-         self % activation_prime => tanh_prime
-         self % activation_name = 'tanh'
+        case default
+            error stop 'Activation must be one of: '// &
+                '"elu", "exponential", "gaussian", "relu", '// &
+                '"sigmoid", "softmax", "softplus", "step", '// &
+                'or "tanh".'
 
-       case default
-         error stop 'Activation must be one of: ' // &
-            '"elu", "exponential", "gaussian", "relu", ' // &
-            '"sigmoid", "softmax", "softplus", "step", ' // &
-            'or "tanh".'
+        end select
 
-      end select
+    end subroutine set_activation
 
-   end subroutine set_activation
+    module subroutine update(self, learning_rate)
+        class(conv2d_layer), intent(in out) :: self
+        real, intent(in) :: learning_rate
 
-   module subroutine update(self, learning_rate)
-      class(conv2d_layer), intent(in out) :: self
-      real, intent(in) :: learning_rate
+        ! Sum weight and bias gradients across images, if any
+        call co_sum(self%dw)
+        call co_sum(self%db)
 
-      ! Sum weight and bias gradients across images, if any
-      call co_sum(self % dw)
-      call co_sum(self % db)
+        self%kernel = self%kernel - learning_rate*self%dw
+        self%biases = self%biases - learning_rate*self%db
+        self%dw = 0
+        self%db = 0
 
-      self % kernel = self % kernel - learning_rate * self % dw
-      self % biases = self % biases - learning_rate * self % db
-      self % dw = 0
-      self % db = 0
-
-   end subroutine update
+    end subroutine update
 
 end submodule nf_conv2d_layer_submodule

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -196,7 +196,7 @@ contains
 
    end function get_num_params
 
-   pure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       class(conv2d_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -200,8 +200,14 @@ contains
       class(conv2d_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 
+      ! automatic reallocation of params
+
       ! first pack the kernel
-      params = [params, pack(self%kernel, .true.)]
+      if (allocated(params)) then
+         params = [params, pack(self%kernel, .true.)]
+      else
+         params = pack(self%kernel, .true.)
+      end if
 
       ! then pack the biases
       params = [params, pack(self % biases, .true.)]

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -196,7 +196,7 @@ contains
 
    end function get_num_params
 
-   module subroutine get_parameters(self, params)
+   pure module subroutine get_parameters(self, params)
       class(conv2d_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -1,268 +1,276 @@
 submodule(nf_conv2d_layer) nf_conv2d_layer_submodule
 
-  use nf_activation_3d, only: activation_function, &
-                              elu, elu_prime, &
-                              exponential, &
-                              gaussian, gaussian_prime, &
-                              relu, relu_prime, &
-                              sigmoid, sigmoid_prime, &
-                              softmax, softmax_prime, &
-                              softplus, softplus_prime, &
-                              step, step_prime, &
-                              tanhf, tanh_prime
-  use nf_random, only: randn
+   use nf_activation_3d, only: activation_function, &
+      elu, elu_prime, &
+      exponential, &
+      gaussian, gaussian_prime, &
+      relu, relu_prime, &
+      sigmoid, sigmoid_prime, &
+      softmax, softmax_prime, &
+      softplus, softplus_prime, &
+      step, step_prime, &
+      tanhf, tanh_prime
+   use nf_random, only: randn
 
-  implicit none
+   implicit none
 
 contains
 
-  pure module function conv2d_layer_cons(filters, kernel_size, activation) result(res)
-    implicit none
-    integer, intent(in) :: filters
-    integer, intent(in) :: kernel_size
-    character(*), intent(in) :: activation
-    type(conv2d_layer) :: res
-    res % kernel_size = kernel_size
-    res % filters = filters
-    call res % set_activation(activation)
-  end function conv2d_layer_cons
+   pure module function conv2d_layer_cons(filters, kernel_size, activation) result(res)
+      implicit none
+      integer, intent(in) :: filters
+      integer, intent(in) :: kernel_size
+      character(*), intent(in) :: activation
+      type(conv2d_layer) :: res
+      res % kernel_size = kernel_size
+      res % filters = filters
+      call res % set_activation(activation)
+   end function conv2d_layer_cons
 
 
-  module subroutine init(self, input_shape)
-    implicit none
-    class(conv2d_layer), intent(in out) :: self
-    integer, intent(in) :: input_shape(:)
+   module subroutine init(self, input_shape)
+      implicit none
+      class(conv2d_layer), intent(in out) :: self
+      integer, intent(in) :: input_shape(:)
 
-    self % channels = input_shape(1)
-    self % width = input_shape(2) - self % kernel_size + 1
-    self % height = input_shape(3) - self % kernel_size + 1
+      self % channels = input_shape(1)
+      self % width = input_shape(2) - self % kernel_size + 1
+      self % height = input_shape(3) - self % kernel_size + 1
 
-    ! Output of shape filters x width x height
-    allocate(self % output(self % filters, self % width, self % height))
-    self % output = 0
+      ! Output of shape filters x width x height
+      allocate(self % output(self % filters, self % width, self % height))
+      self % output = 0
 
-    ! Kernel of shape filters x channels x width x height
-    allocate(self % kernel(self % filters, self % channels, &
-                           self % kernel_size, self % kernel_size))
+      ! Kernel of shape filters x channels x width x height
+      allocate(self % kernel(self % filters, self % channels, &
+         self % kernel_size, self % kernel_size))
 
-    ! Initialize the kernel with random values with a normal distribution.
-    self % kernel = randn(self % filters, self % channels, &
-                          self % kernel_size, self % kernel_size) &
-                  / self % kernel_size**2 !TODO kernel_width * kernel_height
+      ! Initialize the kernel with random values with a normal distribution.
+      self % kernel = randn(self % filters, self % channels, &
+         self % kernel_size, self % kernel_size) &
+         / self % kernel_size**2 !TODO kernel_width * kernel_height
 
-    allocate(self % biases(self % filters))
-    self % biases = 0
+      allocate(self % biases(self % filters))
+      self % biases = 0
 
-    allocate(self % z, mold=self % output)
-    self % z = 0
+      allocate(self % z, mold=self % output)
+      self % z = 0
 
-    allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
-    self % gradient = 0
+      allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
+      self % gradient = 0
 
-    allocate(self % dw, mold=self % kernel)
-    self % dw = 0
+      allocate(self % dw, mold=self % kernel)
+      self % dw = 0
 
-    allocate(self % db, mold=self % biases)
-    self % db = 0
+      allocate(self % db, mold=self % biases)
+      self % db = 0
 
-  end subroutine init
+   end subroutine init
 
 
-  pure module subroutine forward(self, input)
-    implicit none
-    class(conv2d_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    integer :: input_width, input_height, input_channels
-    integer :: istart, iend
-    integer :: jstart, jend
-    integer :: i, j, n
-    integer :: iws, iwe, jws, jwe
-    integer :: half_window
+   pure module subroutine forward(self, input)
+      implicit none
+      class(conv2d_layer), intent(in out) :: self
+      real, intent(in) :: input(:,:,:)
+      integer :: input_width, input_height, input_channels
+      integer :: istart, iend
+      integer :: jstart, jend
+      integer :: i, j, n
+      integer :: iws, iwe, jws, jwe
+      integer :: half_window
 
-    ! Input dimensions are channels x width x height
-    input_channels = size(input, dim=1)
-    input_width = size(input, dim=2)
-    input_height = size(input, dim=3)
+      ! Input dimensions are channels x width x height
+      input_channels = size(input, dim=1)
+      input_width = size(input, dim=2)
+      input_height = size(input, dim=3)
 
-    ! Half-window is 1 for window size 3; 2 for window size 5; etc.
-    half_window = self % kernel_size / 2
+      ! Half-window is 1 for window size 3; 2 for window size 5; etc.
+      half_window = self % kernel_size / 2
 
-    ! Determine the start and end indices for the width and height dimensions
-    ! of the input that correspond to the center of each window.
-    istart = half_window + 1 ! TODO kernel_width
-    jstart = half_window + 1 ! TODO kernel_height
-    iend = input_width - istart + 1
-    jend = input_height - jstart + 1
+      ! Determine the start and end indices for the width and height dimensions
+      ! of the input that correspond to the center of each window.
+      istart = half_window + 1 ! TODO kernel_width
+      jstart = half_window + 1 ! TODO kernel_height
+      iend = input_width - istart + 1
+      jend = input_height - jstart + 1
 
-    convolution: do concurrent(i = istart:iend, j = jstart:jend)
+      convolution: do concurrent(i = istart:iend, j = jstart:jend)
 
-      ! Start and end indices of the input data on the filter window
-      ! iws and jws are also coincidentally the indices of the output matrix
-      iws = i - half_window ! TODO kernel_width
-      iwe = i + half_window ! TODO kernel_width
-      jws = j - half_window ! TODO kernel_height
-      jwe = j + half_window ! TODO kernel_height
+         ! Start and end indices of the input data on the filter window
+         ! iws and jws are also coincidentally the indices of the output matrix
+         iws = i - half_window ! TODO kernel_width
+         iwe = i + half_window ! TODO kernel_width
+         jws = j - half_window ! TODO kernel_height
+         jwe = j + half_window ! TODO kernel_height
 
-      ! Compute the inner tensor product, sum(w_ij * x_ij), for each filter.
-      do concurrent(n = 1:self % filters)
-        self % z(n,iws,jws) = sum(self % kernel(n,:,:,:) * input(:,iws:iwe,jws:jwe))
+         ! Compute the inner tensor product, sum(w_ij * x_ij), for each filter.
+         do concurrent(n = 1:self % filters)
+            self % z(n,iws,jws) = sum(self % kernel(n,:,:,:) * input(:,iws:iwe,jws:jwe))
+         end do
+
+         ! Add bias to the inner product.
+         self % z(:,iws,jws) = self % z(:,iws,jws) + self % biases
+
+      end do convolution
+
+      ! Activate
+      self % output = self % activation(self % z)
+
+   end subroutine forward
+
+
+   pure module subroutine backward(self, input, gradient)
+      implicit none
+      class(conv2d_layer), intent(in out) :: self
+      real, intent(in) :: input(:,:,:)
+      real, intent(in) :: gradient(:,:,:)
+      real :: db(self % filters)
+      real :: dw(self % filters, self % channels, self % kernel_size, self % kernel_size)
+      real :: gdz(self % filters, size(input, 2), size(input, 3))
+      integer :: i, j, k, n
+      integer :: input_channels, input_width, input_height
+      integer :: istart, iend
+      integer :: jstart, jend
+      integer :: iws, iwe, jws, jwe
+      integer :: half_window
+
+      ! Input dimensions are channels x width x height.
+      ! Input frame goes from 1 to input_width and from 1 to input_height.
+      input_channels = size(input, dim=1)
+      input_width = size(input, dim=2)
+      input_height = size(input, dim=3)
+
+      ! Half-window is 1 for window size 3; 2 for window size 5; etc.
+      half_window = self % kernel_size / 2
+
+      ! Determine the start and end indices for the width and height dimensions
+      ! of the input that correspond to the center of each window.
+      istart = half_window + 1 ! TODO kernel_width
+      jstart = half_window + 1 ! TODO kernel_height
+      iend = input_width - istart + 1
+      jend = input_height - jstart + 1
+
+      ! z = w .inner. x + b
+      ! gdz = dL/dy * sigma'(z)
+      gdz = 0
+      gdz(:,istart:iend,jstart:jend) = gradient * self % activation_prime(self % z)
+
+      ! dL/db = sum(dL/dy * sigma'(z))
+      do concurrent (n = 1:self % filters)
+         db(n) = sum(gdz(n,:,:))
       end do
 
-      ! Add bias to the inner product.
-      self % z(:,iws,jws) = self % z(:,iws,jws) + self % biases
+      dw = 0
+      self % gradient = 0
+      do concurrent( &
+         n = 1:self % filters, &
+         k = 1:self % channels, &
+         i = istart:iend, &
+         j = jstart:jend &
+         )
+         ! Start and end indices of the input data on the filter window
+         iws = i - half_window ! TODO kernel_width
+         iwe = i + half_window ! TODO kernel_width
+         jws = j - half_window ! TODO kernel_height
+         jwe = j + half_window ! TODO kernel_height
 
-    end do convolution
+         ! dL/dw = sum(dL/dy * sigma'(z) * x)
+         dw(n,k,:,:) = dw(n,k,:,:) + input(k,iws:iwe,jws:jwe) * gdz(n,iws:iwe,jws:jwe)
 
-    ! Activate
-    self % output = self % activation(self % z)
+         ! dL/dx = dL/dy * sigma'(z) .inner. w
+         self % gradient(k,i,j) = self % gradient(k,i,j) &
+            + sum(gdz(n,iws:iwe,jws:jwe) * self % kernel(n,k,:,:))
 
-  end subroutine forward
+      end do
 
+      self % dw = self % dw + dw
+      self % db = self % db + db
 
-  pure module subroutine backward(self, input, gradient)
-    implicit none
-    class(conv2d_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    real, intent(in) :: gradient(:,:,:)
-    real :: db(self % filters)
-    real :: dw(self % filters, self % channels, self % kernel_size, self % kernel_size)
-    real :: gdz(self % filters, size(input, 2), size(input, 3))
-    integer :: i, j, k, n
-    integer :: input_channels, input_width, input_height
-    integer :: istart, iend
-    integer :: jstart, jend
-    integer :: iws, iwe, jws, jwe
-    integer :: half_window
+   end subroutine backward
 
-    ! Input dimensions are channels x width x height.
-    ! Input frame goes from 1 to input_width and from 1 to input_height.
-    input_channels = size(input, dim=1)
-    input_width = size(input, dim=2)
-    input_height = size(input, dim=3)
+   pure module function get_num_params(self) result(num_params)
+      class(conv2d_layer), intent(in) :: self
+      integer :: num_params
 
-    ! Half-window is 1 for window size 3; 2 for window size 5; etc.
-    half_window = self % kernel_size / 2
+      num_params = self % filters * self % channels * self % kernel_size * self % kernel_size + self % filters
 
-    ! Determine the start and end indices for the width and height dimensions
-    ! of the input that correspond to the center of each window.
-    istart = half_window + 1 ! TODO kernel_width
-    jstart = half_window + 1 ! TODO kernel_height
-    iend = input_width - istart + 1
-    jend = input_height - jstart + 1
+   end function get_num_params
 
-    ! z = w .inner. x + b
-    ! gdz = dL/dy * sigma'(z)
-    gdz = 0
-    gdz(:,istart:iend,jstart:jend) = gradient * self % activation_prime(self % z)
+   elemental module subroutine set_activation(self, activation)
+      class(conv2d_layer), intent(in out) :: self
+      character(*), intent(in) :: activation
 
-    ! dL/db = sum(dL/dy * sigma'(z))
-    do concurrent (n = 1:self % filters)
-      db(n) = sum(gdz(n,:,:))
-    end do
+      select case(trim(activation))
 
-    dw = 0
-    self % gradient = 0
-    do concurrent( &
-      n = 1:self % filters, &
-      k = 1:self % channels, &
-      i = istart:iend, &
-      j = jstart:jend &
-    )
-      ! Start and end indices of the input data on the filter window
-      iws = i - half_window ! TODO kernel_width
-      iwe = i + half_window ! TODO kernel_width
-      jws = j - half_window ! TODO kernel_height
-      jwe = j + half_window ! TODO kernel_height
+         ! TODO need to figure out how to handle the alpha param
+         !case('elu')
+         !  self % activation => elu
+         !  self % activation_prime => elu_prime
+         !  self % activation_name = 'elu'
 
-      ! dL/dw = sum(dL/dy * sigma'(z) * x)
-      dw(n,k,:,:) = dw(n,k,:,:) + input(k,iws:iwe,jws:jwe) * gdz(n,iws:iwe,jws:jwe)
+       case('exponential')
+         self % activation => exponential
+         self % activation_prime => exponential
+         self % activation_name = 'exponential'
 
-      ! dL/dx = dL/dy * sigma'(z) .inner. w
-      self % gradient(k,i,j) = self % gradient(k,i,j) &
-        + sum(gdz(n,iws:iwe,jws:jwe) * self % kernel(n,k,:,:))
+       case('gaussian')
+         self % activation => gaussian
+         self % activation_prime => gaussian_prime
+         self % activation_name = 'gaussian'
 
-    end do
+       case('relu')
+         self % activation => relu
+         self % activation_prime => relu_prime
+         self % activation_name = 'relu'
 
-    self % dw = self % dw + dw
-    self % db = self % db + db
+       case('sigmoid')
+         self % activation => sigmoid
+         self % activation_prime => sigmoid_prime
+         self % activation_name = 'sigmoid'
 
-  end subroutine backward
+       case('softmax')
+         self % activation => softmax
+         self % activation_prime => softmax_prime
+         self % activation_name = 'softmax'
 
-  elemental module subroutine set_activation(self, activation)
-    class(conv2d_layer), intent(in out) :: self
-    character(*), intent(in) :: activation
+       case('softplus')
+         self % activation => softplus
+         self % activation_prime => softplus_prime
+         self % activation_name = 'softplus'
 
-    select case(trim(activation))
+       case('step')
+         self % activation => step
+         self % activation_prime => step_prime
+         self % activation_name = 'step'
 
-      ! TODO need to figure out how to handle the alpha param
-      !case('elu')
-      !  self % activation => elu
-      !  self % activation_prime => elu_prime
-      !  self % activation_name = 'elu'
+       case('tanh')
+         self % activation => tanhf
+         self % activation_prime => tanh_prime
+         self % activation_name = 'tanh'
 
-      case('exponential')
-        self % activation => exponential
-        self % activation_prime => exponential
-        self % activation_name = 'exponential'
+       case default
+         error stop 'Activation must be one of: ' // &
+            '"elu", "exponential", "gaussian", "relu", ' // &
+            '"sigmoid", "softmax", "softplus", "step", ' // &
+            'or "tanh".'
 
-      case('gaussian')
-        self % activation => gaussian
-        self % activation_prime => gaussian_prime
-        self % activation_name = 'gaussian'
+      end select
 
-      case('relu')
-        self % activation => relu
-        self % activation_prime => relu_prime
-        self % activation_name = 'relu'
+   end subroutine set_activation
 
-      case('sigmoid')
-        self % activation => sigmoid
-        self % activation_prime => sigmoid_prime
-        self % activation_name = 'sigmoid'
+   module subroutine update(self, learning_rate)
+      class(conv2d_layer), intent(in out) :: self
+      real, intent(in) :: learning_rate
 
-      case('softmax')
-        self % activation => softmax
-        self % activation_prime => softmax_prime
-        self % activation_name = 'softmax'
+      ! Sum weight and bias gradients across images, if any
+      call co_sum(self % dw)
+      call co_sum(self % db)
 
-      case('softplus')
-        self % activation => softplus
-        self % activation_prime => softplus_prime
-        self % activation_name = 'softplus'
+      self % kernel = self % kernel - learning_rate * self % dw
+      self % biases = self % biases - learning_rate * self % db
+      self % dw = 0
+      self % db = 0
 
-      case('step')
-        self % activation => step
-        self % activation_prime => step_prime
-        self % activation_name = 'step'
-
-      case('tanh')
-        self % activation => tanhf
-        self % activation_prime => tanh_prime
-        self % activation_name = 'tanh'
-
-      case default
-        error stop 'Activation must be one of: ' // &
-          '"elu", "exponential", "gaussian", "relu", ' // &
-          '"sigmoid", "softmax", "softplus", "step", ' // &
-          'or "tanh".'
-
-    end select
-
-  end subroutine set_activation
-
-  module subroutine update(self, learning_rate)
-    class(conv2d_layer), intent(in out) :: self
-    real, intent(in) :: learning_rate
-
-    ! Sum weight and bias gradients across images, if any
-    call co_sum(self % dw)
-    call co_sum(self % db)
-
-    self % kernel = self % kernel - learning_rate * self % dw
-    self % biases = self % biases - learning_rate * self % db
-    self % dw = 0
-    self % db = 0
-
-  end subroutine update
+   end subroutine update
 
 end submodule nf_conv2d_layer_submodule

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -90,7 +90,7 @@ module nf_dense_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+      module subroutine get_parameters(self, params)
          !! Return the parameters of this layer.
          !! The parameters are returned in the order of the weights, then the
          !! biases.

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -81,11 +81,11 @@ module nf_dense_layer
          !! Input from the previous layer
       end subroutine forward
 
-      pure module function get_num_params(self) result(res)
+      pure module function get_num_params(self) result(num_params)
          !! Return the number of parameters in this layer.
          class(dense_layer), intent(in) :: self
          !! Dense layer instance
-         integer :: res
+         integer :: num_params
          !! Number of parameters in this layer
       end function get_num_params
 

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -37,6 +37,7 @@ module nf_dense_layer
       procedure :: backward
       procedure :: forward
       procedure :: get_num_params
+      procedure :: get_parameters
       procedure :: init
       procedure :: set_activation
       procedure :: update
@@ -88,6 +89,16 @@ module nf_dense_layer
          integer :: num_params
          !! Number of parameters in this layer
       end function get_num_params
+
+      pure module subroutine get_parameters(self, params)
+         !! Return the parameters of this layer.
+         !! The parameters are returned in the order of the weights, then the
+         !! biases.
+         class(dense_layer), intent(in) :: self
+         !! Dense layer instance
+         real, intent(inout) :: params(:)
+         !! Parameters of this layer
+      end subroutine get_parameters
 
       module subroutine init(self, input_shape)
          !! Initialize the layer data structures.

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -1,111 +1,120 @@
 module nf_dense_layer
 
-  !! This module provides the concrete dense layer type.
-  !! It is used internally by the layer type.
-  !! It is not intended to be used directly by the user.
+   !! This module provides the concrete dense layer type.
+   !! It is used internally by the layer type.
+   !! It is not intended to be used directly by the user.
 
-  use nf_activation_1d, only: activation_function
-  use nf_base_layer, only: base_layer
+   use nf_activation_1d, only: activation_function
+   use nf_base_layer, only: base_layer
 
-  implicit none
+   implicit none
 
-  private
-  public :: dense_layer
+   private
+   public :: dense_layer
 
-  type, extends(base_layer) :: dense_layer
+   type, extends(base_layer) :: dense_layer
 
-    !! Concrete implementation of a dense (fully-connected) layer type
+      !! Concrete implementation of a dense (fully-connected) layer type
 
-    integer :: input_size
-    integer :: output_size
+      integer :: input_size
+      integer :: output_size
 
-    real, allocatable :: weights(:,:)
-    real, allocatable :: biases(:)
-    real, allocatable :: z(:) ! matmul(x, w) + b
-    real, allocatable :: output(:) ! activation(z)
-    real, allocatable :: gradient(:) ! matmul(w, db)
-    real, allocatable :: dw(:,:) ! weight gradients
-    real, allocatable :: db(:) ! bias gradients
+      real, allocatable :: weights(:,:)
+      real, allocatable :: biases(:)
+      real, allocatable :: z(:) ! matmul(x, w) + b
+      real, allocatable :: output(:) ! activation(z)
+      real, allocatable :: gradient(:) ! matmul(w, db)
+      real, allocatable :: dw(:,:) ! weight gradients
+      real, allocatable :: db(:) ! bias gradients
 
-    procedure(activation_function), pointer, nopass :: &
-      activation => null()
-    procedure(activation_function), pointer, nopass :: &
-      activation_prime => null()
+      procedure(activation_function), pointer, nopass :: &
+         activation => null()
+      procedure(activation_function), pointer, nopass :: &
+         activation_prime => null()
 
-  contains
+   contains
 
-    procedure :: backward
-    procedure :: forward
-    procedure :: init
-    procedure :: set_activation
-    procedure :: update
+      procedure :: backward
+      procedure :: forward
+      procedure :: get_num_params
+      procedure :: init
+      procedure :: set_activation
+      procedure :: update
 
-  end type dense_layer
+   end type dense_layer
 
-  interface dense_layer
-    elemental module function dense_layer_cons(output_size, activation) &
-      result(res)
-      !! This function returns the `dense_layer` instance.
-      integer, intent(in) :: output_size
-        !! Number of neurons in this layer
-      character(*), intent(in) :: activation
-        !! Name of the activation function to use;
-        !! See nf_activation.f90 for available functions.
-      type(dense_layer) :: res
-        !! dense_layer instance
-    end function dense_layer_cons
-  end interface dense_layer
+   interface dense_layer
+      elemental module function dense_layer_cons(output_size, activation) &
+         result(res)
+         !! This function returns the `dense_layer` instance.
+         integer, intent(in) :: output_size
+         !! Number of neurons in this layer
+         character(*), intent(in) :: activation
+         !! Name of the activation function to use;
+         !! See nf_activation.f90 for available functions.
+         type(dense_layer) :: res
+         !! dense_layer instance
+      end function dense_layer_cons
+   end interface dense_layer
 
-  interface
+   interface
 
-    pure module subroutine backward(self, input, gradient)
-      !! Apply the backward gradient descent pass.
-      !! Only weight and bias gradients are updated in this subroutine,
-      !! while the weights and biases themselves are untouched.
-      class(dense_layer), intent(in out) :: self
-        !! Dense layer instance
-      real, intent(in) :: input(:)
-        !! Input from the previous layer
-      real, intent(in) :: gradient(:)
-        !! Gradient from the next layer
-    end subroutine backward
+      pure module subroutine backward(self, input, gradient)
+         !! Apply the backward gradient descent pass.
+         !! Only weight and bias gradients are updated in this subroutine,
+         !! while the weights and biases themselves are untouched.
+         class(dense_layer), intent(in out) :: self
+         !! Dense layer instance
+         real, intent(in) :: input(:)
+         !! Input from the previous layer
+         real, intent(in) :: gradient(:)
+         !! Gradient from the next layer
+      end subroutine backward
 
-    pure module subroutine forward(self, input)
-      !! Propagate forward the layer.
-      !! Calling this subroutine updates the values of a few data components
-      !! of `dense_layer` that are needed for the backward pass.
-      class(dense_layer), intent(in out) :: self
-        !! Dense layer instance
-      real, intent(in) :: input(:)
-        !! Input from the previous layer
-    end subroutine forward
+      pure module subroutine forward(self, input)
+         !! Propagate forward the layer.
+         !! Calling this subroutine updates the values of a few data components
+         !! of `dense_layer` that are needed for the backward pass.
+         class(dense_layer), intent(in out) :: self
+         !! Dense layer instance
+         real, intent(in) :: input(:)
+         !! Input from the previous layer
+      end subroutine forward
 
-    module subroutine init(self, input_shape)
-      !! Initialize the layer data structures.
-      !!
-      !! This is a deferred procedure from the `base_layer` abstract type.
-      class(dense_layer), intent(in out) :: self
-        !! Dense layer instance
-      integer, intent(in) :: input_shape(:)
-        !! Shape of the input layer
-    end subroutine init
+      pure module function get_num_params(self) result(res)
+         !! Return the number of parameters in this layer.
+         class(dense_layer), intent(in) :: self
+         !! Dense layer instance
+         integer :: res
+         !! Number of parameters in this layer
+      end function get_num_params
 
-    elemental module subroutine set_activation(self, activation)
-      !! Set the activation functions.
-      class(dense_layer), intent(in out) :: self
-        !! Layer instance
-      character(*), intent(in) :: activation
-        !! String with the activation function name
-    end subroutine set_activation
+      module subroutine init(self, input_shape)
+         !! Initialize the layer data structures.
+         !!
+         !! This is a deferred procedure from the `base_layer` abstract type.
+         class(dense_layer), intent(in out) :: self
+         !! Dense layer instance
+         integer, intent(in) :: input_shape(:)
+         !! Shape of the input layer
+      end subroutine init
 
-    module subroutine update(self, learning_rate)
-      !! Update the weights and biases.
-      class(dense_layer), intent(in out) :: self
-        !! Dense layer instance
-      real, intent(in) :: learning_rate
-        !! Learning rate (must be > 0)
-    end subroutine update
+      elemental module subroutine set_activation(self, activation)
+         !! Set the activation functions.
+         class(dense_layer), intent(in out) :: self
+         !! Layer instance
+         character(*), intent(in) :: activation
+         !! String with the activation function name
+      end subroutine set_activation
 
-  end interface
+      module subroutine update(self, learning_rate)
+         !! Update the weights and biases.
+         class(dense_layer), intent(in out) :: self
+         !! Dense layer instance
+         real, intent(in) :: learning_rate
+         !! Learning rate (must be > 0)
+      end subroutine update
+
+   end interface
 
 end module nf_dense_layer

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -90,7 +90,7 @@ module nf_dense_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      module subroutine get_parameters(self, params)
+      pure module subroutine get_parameters(self, params)
          !! Return the parameters of this layer.
          !! The parameters are returned in the order of the weights, then the
          !! biases.

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -101,11 +101,11 @@ module nf_dense_layer
          !! Parameters of this layer
         end subroutine get_parameters
 
-        pure module function set_parameters(self, params) result(consumed)
+        module function set_parameters(self, params) result(consumed)
          !! Set the parameters of this layer.
          !! The parameters are set in the order of the weights, then the
          !! biases.
-            class(dense_layer), intent(in) :: self
+            class(dense_layer), intent(in out) :: self
          !! Dense layer instance
             real, intent(in) :: params(:)
          !! Parameters of this layer

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -4,128 +4,141 @@ module nf_dense_layer
    !! It is used internally by the layer type.
    !! It is not intended to be used directly by the user.
 
-   use nf_activation_1d, only: activation_function
-   use nf_base_layer, only: base_layer
+    use nf_activation_1d, only: activation_function
+    use nf_base_layer, only: base_layer
 
-   implicit none
+    implicit none
 
-   private
-   public :: dense_layer
+    private
+    public :: dense_layer
 
-   type, extends(base_layer) :: dense_layer
+    type, extends(base_layer) :: dense_layer
 
       !! Concrete implementation of a dense (fully-connected) layer type
 
-      integer :: input_size
-      integer :: output_size
+        integer :: input_size
+        integer :: output_size
 
-      real, allocatable :: weights(:,:)
-      real, allocatable :: biases(:)
-      real, allocatable :: z(:) ! matmul(x, w) + b
-      real, allocatable :: output(:) ! activation(z)
-      real, allocatable :: gradient(:) ! matmul(w, db)
-      real, allocatable :: dw(:,:) ! weight gradients
-      real, allocatable :: db(:) ! bias gradients
+        real, allocatable :: weights(:, :)
+        real, allocatable :: biases(:)
+        real, allocatable :: z(:) ! matmul(x, w) + b
+        real, allocatable :: output(:) ! activation(z)
+        real, allocatable :: gradient(:) ! matmul(w, db)
+        real, allocatable :: dw(:, :) ! weight gradients
+        real, allocatable :: db(:) ! bias gradients
 
-      procedure(activation_function), pointer, nopass :: &
-         activation => null()
-      procedure(activation_function), pointer, nopass :: &
-         activation_prime => null()
+        procedure(activation_function), pointer, nopass :: &
+            activation => null()
+        procedure(activation_function), pointer, nopass :: &
+            activation_prime => null()
 
-   contains
+    contains
 
-      procedure :: backward
-      procedure :: forward
-      procedure :: get_num_params
-      procedure :: get_parameters
-      procedure :: init
-      procedure :: set_activation
-      procedure :: update
+        procedure :: backward
+        procedure :: forward
+        procedure :: get_num_params
+        procedure :: get_parameters
+        procedure :: set_parameters
+        procedure :: init
+        procedure :: set_activation
+        procedure :: update
 
-   end type dense_layer
+    end type dense_layer
 
-   interface dense_layer
-      elemental module function dense_layer_cons(output_size, activation) &
-         result(res)
+    interface dense_layer
+        elemental module function dense_layer_cons(output_size, activation) &
+            result(res)
          !! This function returns the `dense_layer` instance.
-         integer, intent(in) :: output_size
+            integer, intent(in) :: output_size
          !! Number of neurons in this layer
-         character(*), intent(in) :: activation
+            character(*), intent(in) :: activation
          !! Name of the activation function to use;
          !! See nf_activation.f90 for available functions.
-         type(dense_layer) :: res
+            type(dense_layer) :: res
          !! dense_layer instance
-      end function dense_layer_cons
-   end interface dense_layer
+        end function dense_layer_cons
+    end interface dense_layer
 
-   interface
+    interface
 
-      pure module subroutine backward(self, input, gradient)
+        pure module subroutine backward(self, input, gradient)
          !! Apply the backward gradient descent pass.
          !! Only weight and bias gradients are updated in this subroutine,
          !! while the weights and biases themselves are untouched.
-         class(dense_layer), intent(in out) :: self
+            class(dense_layer), intent(in out) :: self
          !! Dense layer instance
-         real, intent(in) :: input(:)
+            real, intent(in) :: input(:)
          !! Input from the previous layer
-         real, intent(in) :: gradient(:)
+            real, intent(in) :: gradient(:)
          !! Gradient from the next layer
-      end subroutine backward
+        end subroutine backward
 
-      pure module subroutine forward(self, input)
+        pure module subroutine forward(self, input)
          !! Propagate forward the layer.
          !! Calling this subroutine updates the values of a few data components
          !! of `dense_layer` that are needed for the backward pass.
-         class(dense_layer), intent(in out) :: self
+            class(dense_layer), intent(in out) :: self
          !! Dense layer instance
-         real, intent(in) :: input(:)
+            real, intent(in) :: input(:)
          !! Input from the previous layer
-      end subroutine forward
+        end subroutine forward
 
-      pure module function get_num_params(self) result(num_params)
+        pure module function get_num_params(self) result(num_params)
          !! Return the number of parameters in this layer.
-         class(dense_layer), intent(in) :: self
+            class(dense_layer), intent(in) :: self
          !! Dense layer instance
-         integer :: num_params
+            integer :: num_params
          !! Number of parameters in this layer
-      end function get_num_params
+        end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+        pure module subroutine get_parameters(self, params)
          !! Return the parameters of this layer.
          !! The parameters are returned in the order of the weights, then the
          !! biases.
-         class(dense_layer), intent(in) :: self
+            class(dense_layer), intent(in) :: self
          !! Dense layer instance
-         real, allocatable, intent(inout) :: params(:)
+            real, allocatable, intent(inout) :: params(:)
          !! Parameters of this layer
-      end subroutine get_parameters
+        end subroutine get_parameters
 
-      module subroutine init(self, input_shape)
+        pure module function set_parameters(self, params) result(consumed)
+         !! Set the parameters of this layer.
+         !! The parameters are set in the order of the weights, then the
+         !! biases.
+            class(dense_layer), intent(in) :: self
+         !! Dense layer instance
+            real, intent(in) :: params(:)
+         !! Parameters of this layer
+            integer :: consumed
+         !! Number of parameters consumed
+        end function set_parameters
+
+        module subroutine init(self, input_shape)
          !! Initialize the layer data structures.
          !!
          !! This is a deferred procedure from the `base_layer` abstract type.
-         class(dense_layer), intent(in out) :: self
+            class(dense_layer), intent(in out) :: self
          !! Dense layer instance
-         integer, intent(in) :: input_shape(:)
+            integer, intent(in) :: input_shape(:)
          !! Shape of the input layer
-      end subroutine init
+        end subroutine init
 
-      elemental module subroutine set_activation(self, activation)
+        elemental module subroutine set_activation(self, activation)
          !! Set the activation functions.
-         class(dense_layer), intent(in out) :: self
+            class(dense_layer), intent(in out) :: self
          !! Layer instance
-         character(*), intent(in) :: activation
+            character(*), intent(in) :: activation
          !! String with the activation function name
-      end subroutine set_activation
+        end subroutine set_activation
 
-      module subroutine update(self, learning_rate)
+        module subroutine update(self, learning_rate)
          !! Update the weights and biases.
-         class(dense_layer), intent(in out) :: self
+            class(dense_layer), intent(in out) :: self
          !! Dense layer instance
-         real, intent(in) :: learning_rate
+            real, intent(in) :: learning_rate
          !! Learning rate (must be > 0)
-      end subroutine update
+        end subroutine update
 
-   end interface
+    end interface
 
 end module nf_dense_layer

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -96,7 +96,7 @@ module nf_dense_layer
          !! biases.
          class(dense_layer), intent(in) :: self
          !! Dense layer instance
-         real, intent(inout) :: params(:)
+         real, allocatable, intent(inout) :: params(:)
          !! Parameters of this layer
       end subroutine get_parameters
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -1,170 +1,177 @@
 submodule(nf_dense_layer) nf_dense_layer_submodule
 
-  use nf_activation_1d, only: activation_function, &
-                              elu, elu_prime, &
-                              exponential, &
-                              gaussian, gaussian_prime, &
-                              relu, relu_prime, &
-                              sigmoid, sigmoid_prime, &
-                              softmax, softmax_prime, &
-                              softplus, softplus_prime, &
-                              step, step_prime, &
-                              tanhf, tanh_prime
-  use nf_base_layer, only: base_layer
-  use nf_random, only: randn
+   use nf_activation_1d, only: activation_function, &
+      elu, elu_prime, &
+      exponential, &
+      gaussian, gaussian_prime, &
+      relu, relu_prime, &
+      sigmoid, sigmoid_prime, &
+      softmax, softmax_prime, &
+      softplus, softplus_prime, &
+      step, step_prime, &
+      tanhf, tanh_prime
+   use nf_base_layer, only: base_layer
+   use nf_random, only: randn
 
-  implicit none
+   implicit none
 
 contains
 
-  elemental module function dense_layer_cons(output_size, activation) &
-    result(res)
-    integer, intent(in) :: output_size
-    character(*), intent(in) :: activation
-    type(dense_layer) :: res
-    res % output_size = output_size
-    call res % set_activation(activation)
-  end function dense_layer_cons
+   elemental module function dense_layer_cons(output_size, activation) &
+      result(res)
+      integer, intent(in) :: output_size
+      character(*), intent(in) :: activation
+      type(dense_layer) :: res
+      res % output_size = output_size
+      call res % set_activation(activation)
+   end function dense_layer_cons
 
 
-  pure module subroutine backward(self, input, gradient)
-    class(dense_layer), intent(in out) :: self
-    real, intent(in) :: input(:)
-    real, intent(in) :: gradient(:)
-    real :: db(self % output_size)
-    real :: dw(self % input_size, self % output_size)
+   pure module subroutine backward(self, input, gradient)
+      class(dense_layer), intent(in out) :: self
+      real, intent(in) :: input(:)
+      real, intent(in) :: gradient(:)
+      real :: db(self % output_size)
+      real :: dw(self % input_size, self % output_size)
 
-    db = gradient * self % activation_prime(self % z)
-    dw = matmul(reshape(input, [size(input), 1]), reshape(db, [1, size(db)]))
-    self % gradient = matmul(self % weights, db)
-    self % dw = self % dw + dw
-    self % db = self % db + db
+      db = gradient * self % activation_prime(self % z)
+      dw = matmul(reshape(input, [size(input), 1]), reshape(db, [1, size(db)]))
+      self % gradient = matmul(self % weights, db)
+      self % dw = self % dw + dw
+      self % db = self % db + db
 
-  end subroutine backward
-
-
-  pure module subroutine forward(self, input)
-    class(dense_layer), intent(in out) :: self
-    real, intent(in) :: input(:)
-
-    self % z = matmul(input, self % weights) + self % biases
-    self % output = self % activation(self % z)
-
-  end subroutine forward
+   end subroutine backward
 
 
-  module subroutine init(self, input_shape)
-    class(dense_layer), intent(in out) :: self
-    integer, intent(in) :: input_shape(:)
+   pure module subroutine forward(self, input)
+      class(dense_layer), intent(in out) :: self
+      real, intent(in) :: input(:)
 
-    self % input_size = input_shape(1)
+      self % z = matmul(input, self % weights) + self % biases
+      self % output = self % activation(self % z)
 
-    ! Weights are a 2-d array of shape previous layer size
-    ! times this layer size.
-    allocate(self % weights(self % input_size, self % output_size))
-    self % weights = randn(self % input_size, self % output_size) &
-                   / self % input_size
+   end subroutine forward
 
-    ! Broadcast weights to all other images, if any.
-    call co_broadcast(self % weights, 1)
+   pure module function get_num_params(self) result(num_params)
+      class(dense_layer), intent(in) :: self
+      integer :: num_params
 
-    allocate(self % biases(self % output_size))
-    self % biases = 0
+      num_params = self % input_size * self % output_size + self % output_size
 
-    allocate(self % output(self % output_size))
-    self % output = 0
+   end function get_num_params
 
-    allocate(self % z(self % output_size))
-    self % z = 0
+   module subroutine init(self, input_shape)
+      class(dense_layer), intent(in out) :: self
+      integer, intent(in) :: input_shape(:)
 
-    allocate(self % dw(self % input_size, self % output_size))
-    self % dw = 0
+      self % input_size = input_shape(1)
 
-    allocate(self % db(self % output_size))
-    self % db = 0
+      ! Weights are a 2-d array of shape previous layer size
+      ! times this layer size.
+      allocate(self % weights(self % input_size, self % output_size))
+      self % weights = randn(self % input_size, self % output_size) &
+         / self % input_size
 
-    allocate(self % gradient(self % output_size))
-    self % gradient = 0
+      ! Broadcast weights to all other images, if any.
+      call co_broadcast(self % weights, 1)
 
-  end subroutine init
+      allocate(self % biases(self % output_size))
+      self % biases = 0
 
+      allocate(self % output(self % output_size))
+      self % output = 0
 
-  elemental module subroutine set_activation(self, activation)
-    class(dense_layer), intent(in out) :: self
-    character(*), intent(in) :: activation
+      allocate(self % z(self % output_size))
+      self % z = 0
 
-    select case(trim(activation))
+      allocate(self % dw(self % input_size, self % output_size))
+      self % dw = 0
 
-      ! TODO need to figure out how to handle the alpha param
-      !case('elu')
-      !  self % activation => elu
-      !  self % activation_prime => elu_prime
-      !  self % activation_name = 'elu'
+      allocate(self % db(self % output_size))
+      self % db = 0
 
-      case('exponential')
-        self % activation => exponential
-        self % activation_prime => exponential
-        self % activation_name = 'exponential'
+      allocate(self % gradient(self % output_size))
+      self % gradient = 0
 
-      case('gaussian')
-        self % activation => gaussian
-        self % activation_prime => gaussian_prime
-        self % activation_name = 'gaussian'
-
-      case('relu')
-        self % activation => relu
-        self % activation_prime => relu_prime
-        self % activation_name = 'relu'
-
-      case('sigmoid')
-        self % activation => sigmoid
-        self % activation_prime => sigmoid_prime
-        self % activation_name = 'sigmoid'
-
-      case('softmax')
-        self % activation => softmax
-        self % activation_prime => softmax_prime
-        self % activation_name = 'softmax'
-
-      case('softplus')
-        self % activation => softplus
-        self % activation_prime => softplus_prime
-        self % activation_name = 'softplus'
-
-      case('step')
-        self % activation => step
-        self % activation_prime => step_prime
-        self % activation_name = 'step'
-
-      case('tanh')
-        self % activation => tanhf
-        self % activation_prime => tanh_prime
-        self % activation_name = 'tanh'
-
-      case default
-        error stop 'Activation must be one of: ' // &
-          '"elu", "exponential", "gaussian", "relu", ' // &
-          '"sigmoid", "softmax", "softplus", "step", ' // &
-          'or "tanh".'
-
-    end select
-
-  end subroutine set_activation
+   end subroutine init
 
 
-  module subroutine update(self, learning_rate)
-    class(dense_layer), intent(in out) :: self
-    real, intent(in) :: learning_rate
+   elemental module subroutine set_activation(self, activation)
+      class(dense_layer), intent(in out) :: self
+      character(*), intent(in) :: activation
 
-    ! Sum weight and bias gradients across images, if any
-    call co_sum(self % dw)
-    call co_sum(self % db)
+      select case(trim(activation))
 
-    self % weights = self % weights - learning_rate * self % dw
-    self % biases = self % biases - learning_rate * self % db
-    self % dw = 0
-    self % db = 0
+         ! TODO need to figure out how to handle the alpha param
+         !case('elu')
+         !  self % activation => elu
+         !  self % activation_prime => elu_prime
+         !  self % activation_name = 'elu'
 
-  end subroutine update
+       case('exponential')
+         self % activation => exponential
+         self % activation_prime => exponential
+         self % activation_name = 'exponential'
+
+       case('gaussian')
+         self % activation => gaussian
+         self % activation_prime => gaussian_prime
+         self % activation_name = 'gaussian'
+
+       case('relu')
+         self % activation => relu
+         self % activation_prime => relu_prime
+         self % activation_name = 'relu'
+
+       case('sigmoid')
+         self % activation => sigmoid
+         self % activation_prime => sigmoid_prime
+         self % activation_name = 'sigmoid'
+
+       case('softmax')
+         self % activation => softmax
+         self % activation_prime => softmax_prime
+         self % activation_name = 'softmax'
+
+       case('softplus')
+         self % activation => softplus
+         self % activation_prime => softplus_prime
+         self % activation_name = 'softplus'
+
+       case('step')
+         self % activation => step
+         self % activation_prime => step_prime
+         self % activation_name = 'step'
+
+       case('tanh')
+         self % activation => tanhf
+         self % activation_prime => tanh_prime
+         self % activation_name = 'tanh'
+
+       case default
+         error stop 'Activation must be one of: ' // &
+            '"elu", "exponential", "gaussian", "relu", ' // &
+            '"sigmoid", "softmax", "softplus", "step", ' // &
+            'or "tanh".'
+
+      end select
+
+   end subroutine set_activation
+
+
+   module subroutine update(self, learning_rate)
+      class(dense_layer), intent(in out) :: self
+      real, intent(in) :: learning_rate
+
+      ! Sum weight and bias gradients across images, if any
+      call co_sum(self % dw)
+      call co_sum(self % db)
+
+      self % weights = self % weights - learning_rate * self % dw
+      self % biases = self % biases - learning_rate * self % db
+      self % dw = 0
+      self % db = 0
+
+   end subroutine update
 
 end submodule nf_dense_layer_submodule

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -65,14 +65,13 @@ contains
       real, allocatable, intent(inout) :: params(:)
 
       ! automatic reallocation of params
-      if (allocated(params)) then
-         print *, "Reallocating params:", params
-      else
-         print *, "Allocating params"
-      end if
 
       ! first pack the weights
-      params = [params, pack(self % weights, .true.)]
+      if (allocated(params)) then
+         params = [params, pack(self % weights, .true.)]
+      else
+         params = pack(self % weights, .true.)
+      end if
 
       ! then pack the biases
       params = [params, pack(self % biases, .true.)]

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -60,7 +60,7 @@ contains
 
    end function get_num_params
 
-   pure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       class(dense_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -60,7 +60,7 @@ contains
 
    end function get_num_params
 
-   module subroutine get_parameters(self, params)
+   pure module subroutine get_parameters(self, params)
       class(dense_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -65,6 +65,7 @@ contains
       real, allocatable, intent(inout) :: params(:)
 
       ! automatic reallocation of params
+      if (allocated(params)) print *, "Reallocating params:", params
 
       ! first pack the weights
       params = [params, pack(self % weights, .true.)]

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -60,6 +60,16 @@ contains
 
    end function get_num_params
 
+   pure module subroutine get_parameters(self, params)
+      class(dense_layer), intent(in) :: self
+      real, intent(inout) :: params(:)
+
+      params(1:self % input_size * self % output_size) = &
+         reshape(self % weights, [self % input_size * self % output_size])
+
+      params(self % input_size * self % output_size + 1:) = self % biases
+   end subroutine get_parameters
+
    module subroutine init(self, input_shape)
       class(dense_layer), intent(in out) :: self
       integer, intent(in) :: input_shape(:)

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -62,12 +62,18 @@ contains
 
    pure module subroutine get_parameters(self, params)
       class(dense_layer), intent(in) :: self
-      real, intent(inout) :: params(:)
+      real, allocatable, intent(inout) :: params(:)
 
-      params(1:self % input_size * self % output_size) = &
-         reshape(self % weights, [self % input_size * self % output_size])
+      ! first pack the weights
+      if (.not. allocated(params)) then
+         params = pack(self % weights, .true.)
+      else
+         params = [params, pack(self % weights, .true.)]
+      end if
 
-      params(self % input_size * self % output_size + 1:) = self % biases
+      ! then pack the biases (params is certain to have been allocated by this stage)
+      if(allocated(params)) params = [params, pack(self % biases, .true.)]
+
    end subroutine get_parameters
 
    module subroutine init(self, input_shape)

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -64,15 +64,13 @@ contains
       class(dense_layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 
-      ! first pack the weights
-      if (.not. allocated(params)) then
-         params = pack(self % weights, .true.)
-      else
-         params = [params, pack(self % weights, .true.)]
-      end if
+      ! automatic reallocation of params
 
-      ! then pack the biases (params is certain to have been allocated by this stage)
-      if(allocated(params)) params = [params, pack(self % biases, .true.)]
+      ! first pack the weights
+      params = [params, pack(self % weights, .true.)]
+
+      ! then pack the biases
+      params = [params, pack(self % biases, .true.)]
 
    end subroutine get_parameters
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -65,7 +65,11 @@ contains
       real, allocatable, intent(inout) :: params(:)
 
       ! automatic reallocation of params
-      if (allocated(params)) print *, "Reallocating params:", params
+      if (allocated(params)) then
+         print *, "Reallocating params:", params
+      else
+         print *, "Allocating params"
+      end if
 
       ! first pack the weights
       params = [params, pack(self % weights, .true.)]

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -127,7 +127,7 @@ module nf_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      impure module subroutine get_parameters(self, params)
+      module subroutine get_parameters(self, params)
          !! Returns the parameters of this layer.
          class(layer), intent(in) :: self
          !! Layer instance

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -1,134 +1,143 @@
 module nf_layer
 
-  !! This module provides the `layer` type that is part of the public
-  !! user-facing API.
+   !! This module provides the `layer` type that is part of the public
+   !! user-facing API.
 
-  use nf_base_layer, only: base_layer
+   use nf_base_layer, only: base_layer
 
-  implicit none
+   implicit none
 
-  private
-  public :: layer
+   private
+   public :: layer
 
-  type :: layer
+   type :: layer
 
-    !! Main layer type. Use custom constructor functions from
-    !! nf_layer_constructors.f90 to create `layer` instances.
+      !! Main layer type. Use custom constructor functions from
+      !! nf_layer_constructors.f90 to create `layer` instances.
 
-    class(base_layer), allocatable :: p
-    character(:), allocatable :: name
-    character(:), allocatable :: activation
-    integer, allocatable :: layer_shape(:)
-    integer, allocatable :: input_layer_shape(:)
-    logical :: initialized = .false.
+      class(base_layer), allocatable :: p
+      character(:), allocatable :: name
+      character(:), allocatable :: activation
+      integer, allocatable :: layer_shape(:)
+      integer, allocatable :: input_layer_shape(:)
+      logical :: initialized = .false.
 
-  contains
+   contains
 
-    procedure :: forward
-    procedure :: init
-    procedure :: print_info
-    procedure :: update
+      procedure :: forward
+      procedure :: get_num_params
+      procedure :: init
+      procedure :: print_info
+      procedure :: update
 
-    ! Specific subroutines for different array ranks
-    procedure, private :: backward_1d
-    procedure, private :: backward_3d
-    procedure, private :: get_output_1d
-    procedure, private :: get_output_3d
+      ! Specific subroutines for different array ranks
+      procedure, private :: backward_1d
+      procedure, private :: backward_3d
+      procedure, private :: get_output_1d
+      procedure, private :: get_output_3d
 
-    generic :: backward => backward_1d, backward_3d
-    generic :: get_output => get_output_1d, get_output_3d
+      generic :: backward => backward_1d, backward_3d
+      generic :: get_output => get_output_1d, get_output_3d
 
-  end type layer
+   end type layer
 
-  interface backward
+   interface backward
 
-    pure module subroutine backward_1d(self, previous, gradient)
-      !! Apply a backward pass on the layer.
-      !! This changes the internal state of the layer.
-      !! This is normally called internally by the `network % backward`
-      !! method.
-      class(layer), intent(in out) :: self
-        !! Layer instance
-      class(layer), intent(in) :: previous
-        !! Previous layer instance
-      real, intent(in) :: gradient(:)
-        !! Array of gradient values from the next layer
-    end subroutine backward_1d
+      pure module subroutine backward_1d(self, previous, gradient)
+         !! Apply a backward pass on the layer.
+         !! This changes the internal state of the layer.
+         !! This is normally called internally by the `network % backward`
+         !! method.
+         class(layer), intent(in out) :: self
+         !! Layer instance
+         class(layer), intent(in) :: previous
+         !! Previous layer instance
+         real, intent(in) :: gradient(:)
+         !! Array of gradient values from the next layer
+      end subroutine backward_1d
 
-    pure module subroutine backward_3d(self, previous, gradient)
-      !! Apply a backward pass on the layer.
-      !! This changes the internal state of the layer.
-      !! This is normally called internally by the `network % backward`
-      !! method.
-      class(layer), intent(in out) :: self
-        !! Layer instance
-      class(layer), intent(in) :: previous
-        !! Previous layer instance
-      real, intent(in) :: gradient(:,:,:)
-        !! Array of gradient values from the next layer
-    end subroutine backward_3d
+      pure module subroutine backward_3d(self, previous, gradient)
+         !! Apply a backward pass on the layer.
+         !! This changes the internal state of the layer.
+         !! This is normally called internally by the `network % backward`
+         !! method.
+         class(layer), intent(in out) :: self
+         !! Layer instance
+         class(layer), intent(in) :: previous
+         !! Previous layer instance
+         real, intent(in) :: gradient(:,:,:)
+         !! Array of gradient values from the next layer
+      end subroutine backward_3d
 
-  end interface backward
+   end interface backward
 
-  interface
+   interface
 
-    pure module subroutine forward(self, input)
-      !! Apply a forward pass on the layer.
-      !! This changes the internal state of the layer.
-      !! This is normally called internally by the `network % forward`
-      !! method.
-      class(layer), intent(in out) :: self
-        !! Layer instance
-      class(layer), intent(in) :: input
-        !! Input layer instance
-    end subroutine forward
+      pure module subroutine forward(self, input)
+         !! Apply a forward pass on the layer.
+         !! This changes the internal state of the layer.
+         !! This is normally called internally by the `network % forward`
+         !! method.
+         class(layer), intent(in out) :: self
+         !! Layer instance
+         class(layer), intent(in) :: input
+         !! Input layer instance
+      end subroutine forward
 
-    pure module subroutine get_output_1d(self, output)
-      !! Returns the output values (activations) from this layer.
-      class(layer), intent(in) :: self
-        !! Layer instance
-      real, allocatable, intent(out) :: output(:)
-        !! Output values from this layer
-    end subroutine get_output_1d
+      pure module subroutine get_output_1d(self, output)
+         !! Returns the output values (activations) from this layer.
+         class(layer), intent(in) :: self
+         !! Layer instance
+         real, allocatable, intent(out) :: output(:)
+         !! Output values from this layer
+      end subroutine get_output_1d
 
-    pure module subroutine get_output_3d(self, output)
-      !! Returns the output values (activations) from a layer with a 3-d output
-      !! (e.g. input3d, conv2d)
-      class(layer), intent(in) :: self
-        !! Layer instance
-      real, allocatable, intent(out) :: output(:,:,:)
-        !! Output values from this layer
-    end subroutine get_output_3d
+      pure module subroutine get_output_3d(self, output)
+         !! Returns the output values (activations) from a layer with a 3-d output
+         !! (e.g. input3d, conv2d)
+         class(layer), intent(in) :: self
+         !! Layer instance
+         real, allocatable, intent(out) :: output(:,:,:)
+         !! Output values from this layer
+      end subroutine get_output_3d
 
-    impure elemental module subroutine init(self, input)
-      !! Initialize the layer, using information from the input layer,
-      !! i.e. the layer that precedes this one.
-      class(layer), intent(in out) :: self
-        !! Layer instance
-      class(layer), intent(in) :: input
-        !! Input layer instance
-    end subroutine init
+      impure elemental module subroutine init(self, input)
+         !! Initialize the layer, using information from the input layer,
+         !! i.e. the layer that precedes this one.
+         class(layer), intent(in out) :: self
+         !! Layer instance
+         class(layer), intent(in) :: input
+         !! Input layer instance
+      end subroutine init
 
-    impure elemental module subroutine print_info(self)
-      !! Prints a summary information about this layer to the screen.
-      !! This method is called by `network % print_info` for all layers
-      !! on that network.
-      class(layer), intent(in) :: self
-        !! Layer instance
-    end subroutine print_info
+      impure elemental module subroutine print_info(self)
+         !! Prints a summary information about this layer to the screen.
+         !! This method is called by `network % print_info` for all layers
+         !! on that network.
+         class(layer), intent(in) :: self
+         !! Layer instance
+      end subroutine print_info
 
-    impure elemental module subroutine update(self, learning_rate)
-      !! Update the weights and biases on the layer using the stored
-      !! gradients (from backward passes), and flush those same stored
-      !! gradients to zero.
-      !! This changes the state of the layer.
-      !! Typically used only internally from the `network % update` method.
-      class(layer), intent(in out) :: self
-        !! Layer instance
-      real, intent(in) :: learning_rate
-        !! Learning rate to use; must be > 0.
-    end subroutine update
+      pure module function get_num_params(self) result(num_params)
+         !! Returns the number of parameters in this layer.
+         class(layer), intent(in) :: self
+         !! Layer instance
+         integer :: num_params
+         !! Number of parameters in this layer
+      end function get_num_params
 
-  end interface
+      impure elemental module subroutine update(self, learning_rate)
+         !! Update the weights and biases on the layer using the stored
+         !! gradients (from backward passes), and flush those same stored
+         !! gradients to zero.
+         !! This changes the state of the layer.
+         !! Typically used only internally from the `network % update` method.
+         class(layer), intent(in out) :: self
+         !! Layer instance
+         real, intent(in) :: learning_rate
+         !! Learning rate to use; must be > 0.
+      end subroutine update
+
+   end interface
 
 end module nf_layer

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -26,6 +26,7 @@ module nf_layer
 
       procedure :: forward
       procedure :: get_num_params
+      procedure :: get_parameters
       procedure :: init
       procedure :: print_info
       procedure :: update
@@ -125,6 +126,14 @@ module nf_layer
          integer :: num_params
          !! Number of parameters in this layer
       end function get_num_params
+
+      pure module subroutine get_parameters(self, params)
+         !! Returns the parameters of this layer.
+         class(layer), intent(in) :: self
+         !! Layer instance
+         real, allocatable, intent(inout) :: params(:)
+         !! Parameters of this layer
+      end subroutine get_parameters
 
       impure elemental module subroutine update(self, learning_rate)
          !! Update the weights and biases on the layer using the stored

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -3,150 +3,160 @@ module nf_layer
    !! This module provides the `layer` type that is part of the public
    !! user-facing API.
 
-   use nf_base_layer, only: base_layer
+    use nf_base_layer, only: base_layer
 
-   implicit none
+    implicit none
 
-   private
-   public :: layer
+    private
+    public :: layer
 
-   type :: layer
+    type :: layer
 
       !! Main layer type. Use custom constructor functions from
       !! nf_layer_constructors.f90 to create `layer` instances.
 
-      class(base_layer), allocatable :: p
-      character(:), allocatable :: name
-      character(:), allocatable :: activation
-      integer, allocatable :: layer_shape(:)
-      integer, allocatable :: input_layer_shape(:)
-      logical :: initialized = .false.
+        class(base_layer), allocatable :: p
+        character(:), allocatable :: name
+        character(:), allocatable :: activation
+        integer, allocatable :: layer_shape(:)
+        integer, allocatable :: input_layer_shape(:)
+        logical :: initialized = .false.
 
-   contains
+    contains
 
-      procedure :: forward
-      procedure :: get_num_params
-      procedure :: get_parameters
-      procedure :: init
-      procedure :: print_info
-      procedure :: update
+        procedure :: forward
+        procedure :: get_num_params
+        procedure :: get_parameters
+        procedure :: set_parameters
+        procedure :: init
+        procedure :: print_info
+        procedure :: update
 
-      ! Specific subroutines for different array ranks
-      procedure, private :: backward_1d
-      procedure, private :: backward_3d
-      procedure, private :: get_output_1d
-      procedure, private :: get_output_3d
+        ! Specific subroutines for different array ranks
+        procedure, private :: backward_1d
+        procedure, private :: backward_3d
+        procedure, private :: get_output_1d
+        procedure, private :: get_output_3d
 
-      generic :: backward => backward_1d, backward_3d
-      generic :: get_output => get_output_1d, get_output_3d
+        generic :: backward => backward_1d, backward_3d
+        generic :: get_output => get_output_1d, get_output_3d
 
-   end type layer
+    end type layer
 
-   interface backward
+    interface backward
 
-      pure module subroutine backward_1d(self, previous, gradient)
+        pure module subroutine backward_1d(self, previous, gradient)
          !! Apply a backward pass on the layer.
          !! This changes the internal state of the layer.
          !! This is normally called internally by the `network % backward`
          !! method.
-         class(layer), intent(in out) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
-         class(layer), intent(in) :: previous
+            class(layer), intent(in) :: previous
          !! Previous layer instance
-         real, intent(in) :: gradient(:)
+            real, intent(in) :: gradient(:)
          !! Array of gradient values from the next layer
-      end subroutine backward_1d
+        end subroutine backward_1d
 
-      pure module subroutine backward_3d(self, previous, gradient)
+        pure module subroutine backward_3d(self, previous, gradient)
          !! Apply a backward pass on the layer.
          !! This changes the internal state of the layer.
          !! This is normally called internally by the `network % backward`
          !! method.
-         class(layer), intent(in out) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
-         class(layer), intent(in) :: previous
+            class(layer), intent(in) :: previous
          !! Previous layer instance
-         real, intent(in) :: gradient(:,:,:)
+            real, intent(in) :: gradient(:, :, :)
          !! Array of gradient values from the next layer
-      end subroutine backward_3d
+        end subroutine backward_3d
 
-   end interface backward
+    end interface backward
 
-   interface
+    interface
 
-      pure module subroutine forward(self, input)
+        pure module subroutine forward(self, input)
          !! Apply a forward pass on the layer.
          !! This changes the internal state of the layer.
          !! This is normally called internally by the `network % forward`
          !! method.
-         class(layer), intent(in out) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
-         class(layer), intent(in) :: input
+            class(layer), intent(in) :: input
          !! Input layer instance
-      end subroutine forward
+        end subroutine forward
 
-      pure module subroutine get_output_1d(self, output)
+        pure module subroutine get_output_1d(self, output)
          !! Returns the output values (activations) from this layer.
-         class(layer), intent(in) :: self
+            class(layer), intent(in) :: self
          !! Layer instance
-         real, allocatable, intent(out) :: output(:)
+            real, allocatable, intent(out) :: output(:)
          !! Output values from this layer
-      end subroutine get_output_1d
+        end subroutine get_output_1d
 
-      pure module subroutine get_output_3d(self, output)
+        pure module subroutine get_output_3d(self, output)
          !! Returns the output values (activations) from a layer with a 3-d output
          !! (e.g. input3d, conv2d)
-         class(layer), intent(in) :: self
+            class(layer), intent(in) :: self
          !! Layer instance
-         real, allocatable, intent(out) :: output(:,:,:)
+            real, allocatable, intent(out) :: output(:, :, :)
          !! Output values from this layer
-      end subroutine get_output_3d
+        end subroutine get_output_3d
 
-      impure elemental module subroutine init(self, input)
+        impure elemental module subroutine init(self, input)
          !! Initialize the layer, using information from the input layer,
          !! i.e. the layer that precedes this one.
-         class(layer), intent(in out) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
-         class(layer), intent(in) :: input
+            class(layer), intent(in) :: input
          !! Input layer instance
-      end subroutine init
+        end subroutine init
 
-      impure elemental module subroutine print_info(self)
+        impure elemental module subroutine print_info(self)
          !! Prints a summary information about this layer to the screen.
          !! This method is called by `network % print_info` for all layers
          !! on that network.
-         class(layer), intent(in) :: self
+            class(layer), intent(in) :: self
          !! Layer instance
-      end subroutine print_info
+        end subroutine print_info
 
-      pure module function get_num_params(self) result(num_params)
+        pure module function get_num_params(self) result(num_params)
          !! Returns the number of parameters in this layer.
-         class(layer), intent(in) :: self
+            class(layer), intent(in) :: self
          !! Layer instance
-         integer :: num_params
+            integer :: num_params
          !! Number of parameters in this layer
-      end function get_num_params
+        end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+        pure module subroutine get_parameters(self, params)
          !! Returns the parameters of this layer.
-         class(layer), intent(in) :: self
+            class(layer), intent(in) :: self
          !! Layer instance
-         real, allocatable, intent(inout) :: params(:)
+            real, allocatable, intent(inout) :: params(:)
          !! Parameters of this layer
-      end subroutine get_parameters
+        end subroutine get_parameters
 
-      impure elemental module subroutine update(self, learning_rate)
+        pure module function set_parameters(self, params) result(consumed)
+         !! Returns the parameters of this layer.
+            class(layer), intent(in) :: self
+         !! Layer instance
+            real, intent(in) :: params(:)
+         !! Parameters of this layer
+            integer :: consumed
+        end function set_parameters
+
+        impure elemental module subroutine update(self, learning_rate)
          !! Update the weights and biases on the layer using the stored
          !! gradients (from backward passes), and flush those same stored
          !! gradients to zero.
          !! This changes the state of the layer.
          !! Typically used only internally from the `network % update` method.
-         class(layer), intent(in out) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
-         real, intent(in) :: learning_rate
+            real, intent(in) :: learning_rate
          !! Learning rate to use; must be > 0.
-      end subroutine update
+        end subroutine update
 
-   end interface
+    end interface
 
 end module nf_layer

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -127,7 +127,7 @@ module nf_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+      impure module subroutine get_parameters(self, params)
          !! Returns the parameters of this layer.
          class(layer), intent(in) :: self
          !! Layer instance

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -136,9 +136,9 @@ module nf_layer
          !! Parameters of this layer
         end subroutine get_parameters
 
-        pure module function set_parameters(self, params) result(consumed)
+        impure module function set_parameters(self, params) result(consumed)
          !! Returns the parameters of this layer.
-            class(layer), intent(in) :: self
+            class(layer), intent(in out) :: self
          !! Layer instance
             real, intent(in) :: params(:)
          !! Parameters of this layer

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -127,7 +127,7 @@ module nf_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      module subroutine get_parameters(self, params)
+      pure module subroutine get_parameters(self, params)
          !! Returns the parameters of this layer.
          class(layer), intent(in) :: self
          !! Layer instance

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -127,7 +127,7 @@ module nf_layer
          !! Number of parameters in this layer
       end function get_num_params
 
-      pure module subroutine get_parameters(self, params)
+      module subroutine get_parameters(self, params)
          !! Returns the parameters of this layer.
          class(layer), intent(in) :: self
          !! Layer instance

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -1,332 +1,356 @@
 submodule(nf_layer) nf_layer_submodule
 
-   use nf_conv2d_layer, only: conv2d_layer
-   use nf_dense_layer, only: dense_layer
-   use nf_flatten_layer, only: flatten_layer
-   use nf_input1d_layer, only: input1d_layer
-   use nf_input3d_layer, only: input3d_layer
-   use nf_maxpool2d_layer, only: maxpool2d_layer
-   use nf_reshape_layer, only: reshape3d_layer
+    use nf_conv2d_layer, only: conv2d_layer
+    use nf_dense_layer, only: dense_layer
+    use nf_flatten_layer, only: flatten_layer
+    use nf_input1d_layer, only: input1d_layer
+    use nf_input3d_layer, only: input3d_layer
+    use nf_maxpool2d_layer, only: maxpool2d_layer
+    use nf_reshape_layer, only: reshape3d_layer
 
 contains
 
-   pure module subroutine backward_1d(self, previous, gradient)
-      implicit none
-      class(layer), intent(in out) :: self
-      class(layer), intent(in) :: previous
-      real, intent(in) :: gradient(:)
+    pure module subroutine backward_1d(self, previous, gradient)
+        implicit none
+        class(layer), intent(in out) :: self
+        class(layer), intent(in) :: previous
+        real, intent(in) :: gradient(:)
 
-      ! Backward pass from a 1-d layer downstream currently implemented
-      ! only for dense and flatten layers
-      select type(this_layer => self % p)
+        ! Backward pass from a 1-d layer downstream currently implemented
+        ! only for dense and flatten layers
+        select type (this_layer => self%p)
 
-       type is(dense_layer)
+        type is (dense_layer)
 
-         ! Upstream layers permitted: input1d, dense, flatten
-         select type(prev_layer => previous % p)
-          type is(input1d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(dense_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(flatten_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-         end select
+            ! Upstream layers permitted: input1d, dense, flatten
+            select type (prev_layer => previous%p)
+            type is (input1d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (dense_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (flatten_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            end select
 
-       type is(flatten_layer)
+        type is (flatten_layer)
 
-         ! Upstream layers permitted: input3d, conv2d, maxpool2d
-         select type(prev_layer => previous % p)
-          type is(input3d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(conv2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(maxpool2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-         end select
+            ! Upstream layers permitted: input3d, conv2d, maxpool2d
+            select type (prev_layer => previous%p)
+            type is (input3d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (conv2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (maxpool2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            end select
 
-      end select
+        end select
 
-   end subroutine backward_1d
+    end subroutine backward_1d
 
+    pure module subroutine backward_3d(self, previous, gradient)
+        implicit none
+        class(layer), intent(in out) :: self
+        class(layer), intent(in) :: previous
+        real, intent(in) :: gradient(:, :, :)
 
-   pure module subroutine backward_3d(self, previous, gradient)
-      implicit none
-      class(layer), intent(in out) :: self
-      class(layer), intent(in) :: previous
-      real, intent(in) :: gradient(:,:,:)
+        ! Backward pass from a 3-d layer downstream currently implemented
+        ! only for conv2d and reshape3d layers
+        select type (this_layer => self%p)
 
-      ! Backward pass from a 3-d layer downstream currently implemented
-      ! only for conv2d and reshape3d layers
-      select type(this_layer => self % p)
+        type is (conv2d_layer)
 
-       type is(conv2d_layer)
+            ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
+            select type (prev_layer => previous%p)
+            type is (maxpool2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (input3d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (conv2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (reshape3d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            end select
 
-         ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
-         select type(prev_layer => previous % p)
-          type is(maxpool2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(input3d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(conv2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(reshape3d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-         end select
+        type is (maxpool2d_layer)
 
-       type is(maxpool2d_layer)
+            ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
+            select type (prev_layer => previous%p)
+            type is (conv2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (maxpool2d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (input3d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (reshape3d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            end select
 
-         ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
-         select type(prev_layer => previous % p)
-          type is(conv2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(maxpool2d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(input3d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(reshape3d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-         end select
+        type is (reshape3d_layer)
 
-       type is(reshape3d_layer)
+            ! Upstream layers permitted: input1d, dense, flatten
+            select type (prev_layer => previous%p)
+            type is (input1d_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (dense_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            type is (flatten_layer)
+                call this_layer%backward(prev_layer%output, gradient)
+            end select
 
-         ! Upstream layers permitted: input1d, dense, flatten
-         select type(prev_layer => previous % p)
-          type is(input1d_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(dense_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-          type is(flatten_layer)
-            call this_layer % backward(prev_layer % output, gradient)
-         end select
+        end select
 
-      end select
+    end subroutine backward_3d
 
-   end subroutine backward_3d
+    pure module subroutine forward(self, input)
+        implicit none
+        class(layer), intent(in out) :: self
+        class(layer), intent(in) :: input
 
+        select type (this_layer => self%p)
 
-   pure module subroutine forward(self, input)
-      implicit none
-      class(layer), intent(in out) :: self
-      class(layer), intent(in) :: input
+        type is (dense_layer)
 
-      select type(this_layer => self % p)
+            ! Upstream layers permitted: input1d, dense, flatten
+            select type (prev_layer => input%p)
+            type is (input1d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (dense_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (flatten_layer)
+                call this_layer%forward(prev_layer%output)
+            end select
 
-       type is(dense_layer)
+        type is (conv2d_layer)
 
-         ! Upstream layers permitted: input1d, dense, flatten
-         select type(prev_layer => input % p)
-          type is(input1d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(dense_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(flatten_layer)
-            call this_layer % forward(prev_layer % output)
-         end select
+            ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+            select type (prev_layer => input%p)
+            type is (input3d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (conv2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (maxpool2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (reshape3d_layer)
+                call this_layer%forward(prev_layer%output)
+            end select
 
-       type is(conv2d_layer)
+        type is (maxpool2d_layer)
 
-         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-         select type(prev_layer => input % p)
-          type is(input3d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(conv2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(maxpool2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(reshape3d_layer)
-            call this_layer % forward(prev_layer % output)
-         end select
+            ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+            select type (prev_layer => input%p)
+            type is (input3d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (conv2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (maxpool2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (reshape3d_layer)
+                call this_layer%forward(prev_layer%output)
+            end select
 
-       type is(maxpool2d_layer)
+        type is (flatten_layer)
 
-         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-         select type(prev_layer => input % p)
-          type is(input3d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(conv2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(maxpool2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(reshape3d_layer)
-            call this_layer % forward(prev_layer % output)
-         end select
+            ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+            select type (prev_layer => input%p)
+            type is (input3d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (conv2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (maxpool2d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (reshape3d_layer)
+                call this_layer%forward(prev_layer%output)
+            end select
 
-       type is(flatten_layer)
+        type is (reshape3d_layer)
 
-         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-         select type(prev_layer => input % p)
-          type is(input3d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(conv2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(maxpool2d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(reshape3d_layer)
-            call this_layer % forward(prev_layer % output)
-         end select
+            ! Upstream layers permitted: input1d, dense, flatten
+            select type (prev_layer => input%p)
+            type is (input1d_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (dense_layer)
+                call this_layer%forward(prev_layer%output)
+            type is (flatten_layer)
+                call this_layer%forward(prev_layer%output)
+            end select
 
-       type is(reshape3d_layer)
+        end select
 
-         ! Upstream layers permitted: input1d, dense, flatten
-         select type(prev_layer => input % p)
-          type is(input1d_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(dense_layer)
-            call this_layer % forward(prev_layer % output)
-          type is(flatten_layer)
-            call this_layer % forward(prev_layer % output)
-         end select
+    end subroutine forward
 
-      end select
+    pure module subroutine get_output_1d(self, output)
+        implicit none
+        class(layer), intent(in) :: self
+        real, allocatable, intent(out) :: output(:)
 
-   end subroutine forward
+        select type (this_layer => self%p)
 
+        type is (input1d_layer)
+            allocate (output, source=this_layer%output)
+        type is (dense_layer)
+            allocate (output, source=this_layer%output)
+        type is (flatten_layer)
+            allocate (output, source=this_layer%output)
+        class default
+            error stop '1-d output can only be read from an input1d, dense, or flatten layer.'
 
-   pure module subroutine get_output_1d(self, output)
-      implicit none
-      class(layer), intent(in) :: self
-      real, allocatable, intent(out) :: output(:)
+        end select
 
-      select type(this_layer => self % p)
+    end subroutine get_output_1d
 
-       type is(input1d_layer)
-         allocate(output, source=this_layer % output)
-       type is(dense_layer)
-         allocate(output, source=this_layer % output)
-       type is(flatten_layer)
-         allocate(output, source=this_layer % output)
-       class default
-         error stop '1-d output can only be read from an input1d, dense, or flatten layer.'
+    pure module subroutine get_output_3d(self, output)
+        implicit none
+        class(layer), intent(in) :: self
+        real, allocatable, intent(out) :: output(:, :, :)
 
-      end select
+        select type (this_layer => self%p)
 
-   end subroutine get_output_1d
+        type is (input3d_layer)
+            allocate (output, source=this_layer%output)
+        type is (conv2d_layer)
+            allocate (output, source=this_layer%output)
+        type is (maxpool2d_layer)
+            allocate (output, source=this_layer%output)
+        type is (reshape3d_layer)
+            allocate (output, source=this_layer%output)
+        class default
+            error stop '3-d output can only be read from a conv2d, input3d, maxpool2d, or reshape3d layer.'
 
+        end select
 
-   pure module subroutine get_output_3d(self, output)
-      implicit none
-      class(layer), intent(in) :: self
-      real, allocatable, intent(out) :: output(:,:,:)
+    end subroutine get_output_3d
 
-      select type(this_layer => self % p)
+    impure elemental module subroutine init(self, input)
+        implicit none
+        class(layer), intent(in out) :: self
+        class(layer), intent(in) :: input
 
-       type is(input3d_layer)
-         allocate(output, source=this_layer % output)
-       type is(conv2d_layer)
-         allocate(output, source=this_layer % output)
-       type is(maxpool2d_layer)
-         allocate(output, source=this_layer % output)
-       type is(reshape3d_layer)
-         allocate(output, source=this_layer % output)
-       class default
-         error stop '3-d output can only be read from a conv2d, input3d, maxpool2d, or reshape3d layer.'
+        if (self%initialized) &
+            error stop self%name//' layer is already initialized.'
 
-      end select
+        select type (this_layer => self%p); class default
+            call this_layer%init(input%layer_shape)
+        end select
 
-   end subroutine get_output_3d
+        ! The shape of conv2d, maxpool2d, or flatten layers is not known
+        ! until we receive an input layer.
+        select type (this_layer => self%p)
+        type is (conv2d_layer)
+            self%layer_shape = shape(this_layer%output)
+        type is (maxpool2d_layer)
+            self%layer_shape = shape(this_layer%output)
+        type is (flatten_layer)
+            self%layer_shape = shape(this_layer%output)
+        end select
 
+        self%input_layer_shape = input%layer_shape
+        self%initialized = .true.
 
-   impure elemental module subroutine init(self, input)
-      implicit none
-      class(layer), intent(in out) :: self
-      class(layer), intent(in) :: input
+    end subroutine init
 
-      if (self % initialized) &
-         error stop self % name // ' layer is already initialized.'
+    impure elemental module subroutine print_info(self)
+        implicit none
+        class(layer), intent(in) :: self
+        print '("Layer: ", a)', self%name
+        print '(60("-"))'
+        if (.not. self%name == 'input') &
+            print '("Input shape: ", *(i0, 1x))', self%input_layer_shape
+        print '("Output shape: ", *(i0, 1x))', self%layer_shape
+        if (.not. self%name == 'input') &
+            print '("Activation: ", a)', self%activation
+        print *
+    end subroutine print_info
 
-      select type(this_layer => self % p); class default
-         call this_layer % init(input % layer_shape)
-      end select
+    pure module function get_num_params(self) result(num_params)
+        implicit none
+        class(layer), intent(in) :: self
+        integer :: num_params
 
-      ! The shape of conv2d, maxpool2d, or flatten layers is not known
-      ! until we receive an input layer.
-      select type(this_layer => self % p)
-       type is(conv2d_layer)
-         self % layer_shape = shape(this_layer % output)
-       type is(maxpool2d_layer)
-         self % layer_shape = shape(this_layer % output)
-       type is(flatten_layer)
-         self % layer_shape = shape(this_layer % output)
-      end select
+        select type (this_layer => self%p)
+        type is (input1d_layer)
+            num_params = 0
+        type is (input3d_layer)
+            num_params = 0
+        type is (dense_layer)
+            num_params = this_layer%get_num_params()
+        type is (conv2d_layer)
+            num_params = this_layer%get_num_params()
+        type is (maxpool2d_layer)
+            num_params = 0
+        type is (flatten_layer)
+            num_params = 0
+        type is (reshape3d_layer)
+            num_params = 0
+        class default
+            error stop 'Unknown layer type.'
+        end select
 
-      self % input_layer_shape = input % layer_shape
-      self % initialized = .true.
+    end function get_num_params
 
-   end subroutine init
+    pure module subroutine get_parameters(self, params)
+        class(layer), intent(in) :: self
+        real, allocatable, intent(inout) :: params(:)
 
+        select type (this_layer => self%p)
+        type is (input1d_layer)
+            ! No parameters to get.
+        type is (input3d_layer)
+            ! No parameters to get.
+        type is (dense_layer)
+            call this_layer%get_parameters(params)
+        type is (conv2d_layer)
+            call this_layer%get_parameters(params)
+        type is (maxpool2d_layer)
+            ! No parameters to get.
+        type is (flatten_layer)
+            ! No parameters to get.
+        type is (reshape3d_layer)
+            ! No parameters to get.
+        class default
+            error stop 'Unknown layer type.'
+        end select
+    end subroutine get_parameters
 
-   impure elemental module subroutine print_info(self)
-      implicit none
-      class(layer), intent(in) :: self
-      print '("Layer: ", a)', self % name
-      print '(60("-"))'
-      if (.not. self % name == 'input') &
-         print '("Input shape: ", *(i0, 1x))', self % input_layer_shape
-      print '("Output shape: ", *(i0, 1x))', self % layer_shape
-      if (.not. self % name == 'input') &
-         print '("Activation: ", a)', self % activation
-      print *
-   end subroutine print_info
+    pure module function set_parameters(self, params) result(consumed)
+        class(layer), intent(in) :: self
+        real, intent(in) :: params(:)
+        integer :: consumed
 
-   pure module function get_num_params(self) result(num_params)
-      implicit none
-      class(layer), intent(in) :: self
-      integer :: num_params
+        select type (this_layer => self%p)
+        type is (input1d_layer)
+            ! No parameters to set.
+            consumed = 0
+        type is (input3d_layer)
+            ! No parameters to set.
+            consumed = 0
+        type is (dense_layer)
+            consumed = this_layer%set_parameters(params)
+        type is (conv2d_layer)
+            consumed = this_layer%set_parameters(params)
+        type is (maxpool2d_layer)
+            ! No parameters to set.
+            consumed = 0
+        type is (flatten_layer)
+            ! No parameters to set.
+            consumed = 0
+        type is (reshape3d_layer)
+            ! No parameters to set.
+            consumed = 0
+        class default
+            error stop 'Unknown layer type.'
+        end select
+    end function set_parameters
 
-      select type(this_layer => self % p)
-       type is(input1d_layer)
-         num_params = 0
-       type is(input3d_layer)
-         num_params = 0
-       type is(dense_layer)
-         num_params = this_layer % get_num_params()
-       type is(conv2d_layer)
-         num_params = this_layer % get_num_params()
-       type is(maxpool2d_layer)
-         num_params = 0
-       type is(flatten_layer)
-         num_params = 0
-       type is(reshape3d_layer)
-         num_params = 0
-       class default
-         error stop 'Unknown layer type.'
-      end select
+    impure elemental module subroutine update(self, learning_rate)
+        implicit none
+        class(layer), intent(in out) :: self
+        real, intent(in) :: learning_rate
 
-   end function get_num_params
+        select type (this_layer => self%p); type is (dense_layer)
+            call this_layer%update(learning_rate)
+        end select
 
-   pure module subroutine get_parameters(self, params)
-      class(layer), intent(in) :: self
-      real, allocatable, intent(inout) :: params(:)
-
-      select type(this_layer => self % p)
-       type is(input1d_layer)
-         ! No parameters to get.
-       type is(input3d_layer)
-         ! No parameters to get.
-       type is(dense_layer)
-         call this_layer % get_parameters(params)
-       type is(conv2d_layer)
-         call this_layer % get_parameters(params)
-       type is(maxpool2d_layer)
-         ! No parameters to get.
-       type is(flatten_layer)
-         ! No parameters to get.
-       type is(reshape3d_layer)
-         ! No parameters to get.
-       class default
-         error stop 'Unknown layer type.'
-      end select
-   end subroutine get_parameters
-
-   impure elemental module subroutine update(self, learning_rate)
-      implicit none
-      class(layer), intent(in out) :: self
-      real, intent(in) :: learning_rate
-
-      select type(this_layer => self % p); type is(dense_layer)
-         call this_layer % update(learning_rate)
-      end select
-
-   end subroutine update
+    end subroutine update
 
 end submodule nf_layer_submodule

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -294,7 +294,7 @@ contains
 
    end function get_num_params
 
-   pure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       class(layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -327,7 +327,8 @@ contains
         type is (dense_layer)
             consumed = this_layer%set_parameters(params)
         type is (conv2d_layer)
-            consumed = this_layer%set_parameters(params)
+            ! consumed = this_layer%set_parameters(params)
+            consumed = 0
         type is (maxpool2d_layer)
             ! No parameters to set.
             consumed = 0

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -306,7 +306,7 @@ contains
        type is(dense_layer)
          call this_layer % get_parameters(params)
        type is(conv2d_layer)
-         ! call this_layer % get_parameters(params)
+         call this_layer % get_parameters(params)
        type is(maxpool2d_layer)
          ! No parameters to get.
        type is(flatten_layer)

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -304,7 +304,7 @@ contains
        type is(input3d_layer)
          ! No parameters to get.
        type is(dense_layer)
-         ! call this_layer % get_parameters(params)
+         call this_layer % get_parameters(params)
        type is(conv2d_layer)
          ! call this_layer % get_parameters(params)
        type is(maxpool2d_layer)

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -327,8 +327,7 @@ contains
         type is (dense_layer)
             consumed = this_layer%set_parameters(params)
         type is (conv2d_layer)
-            ! consumed = this_layer%set_parameters(params)
-            consumed = 0
+            consumed = this_layer%set_parameters(params)
         type is (maxpool2d_layer)
             ! No parameters to set.
             consumed = 0

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -292,31 +292,31 @@ contains
          error stop 'Unknown layer type.'
       end select
 
-      impure module subroutine get_parameters(self, params)
-         class(layer), intent(in) :: self
-         real, allocatable, intent(inout) :: params(:)
-
-         select type(this_layer => self % p)
-          type is(input1d_layer)
-            ! No parameters to get.
-          type is(input3d_layer)
-            ! No parameters to get.
-          type is(dense_layer)
-            call this_layer % get_parameters(params)
-          type is(conv2d_layer)
-            call this_layer % get_parameters(params)
-          type is(maxpool2d_layer)
-            ! No parameters to get.
-          type is(flatten_layer)
-            ! No parameters to get.
-          type is(reshape3d_layer)
-            ! No parameters to get.
-          class default
-            error stop 'Unknown layer type.'
-         end select
-      end subroutine get_parameters
-
    end function get_num_params
+
+   module subroutine get_parameters(self, params)
+      class(layer), intent(in) :: self
+      real, allocatable, intent(inout) :: params(:)
+
+      select type(this_layer => self % p)
+       type is(input1d_layer)
+         ! No parameters to get.
+       type is(input3d_layer)
+         ! No parameters to get.
+       type is(dense_layer)
+         ! call this_layer % get_parameters(params)
+       type is(conv2d_layer)
+         ! call this_layer % get_parameters(params)
+       type is(maxpool2d_layer)
+         ! No parameters to get.
+       type is(flatten_layer)
+         ! No parameters to get.
+       type is(reshape3d_layer)
+         ! No parameters to get.
+       class default
+         error stop 'Unknown layer type.'
+      end select
+   end subroutine get_parameters
 
    impure elemental module subroutine update(self, learning_rate)
       implicit none

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -312,8 +312,8 @@ contains
         end select
     end subroutine get_parameters
 
-    pure module function set_parameters(self, params) result(consumed)
-        class(layer), intent(in) :: self
+    impure module function set_parameters(self, params) result(consumed)
+        class(layer), intent(in out) :: self
         real, intent(in) :: params(:)
         integer :: consumed
 

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -294,7 +294,7 @@ contains
 
    end function get_num_params
 
-   module subroutine get_parameters(self, params)
+   pure module subroutine get_parameters(self, params)
       class(layer), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
 

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -292,6 +292,30 @@ contains
          error stop 'Unknown layer type.'
       end select
 
+      impure module subroutine get_parameters(self, params)
+         class(layer), intent(in) :: self
+         real, allocatable, intent(inout) :: params(:)
+
+         select type(this_layer => self % p)
+          type is(input1d_layer)
+            ! No parameters to get.
+          type is(input3d_layer)
+            ! No parameters to get.
+          type is(dense_layer)
+            call this_layer % get_parameters(params)
+          type is(conv2d_layer)
+            call this_layer % get_parameters(params)
+          type is(maxpool2d_layer)
+            ! No parameters to get.
+          type is(flatten_layer)
+            ! No parameters to get.
+          type is(reshape3d_layer)
+            ! No parameters to get.
+          class default
+            error stop 'Unknown layer type.'
+         end select
+      end subroutine get_parameters
+
    end function get_num_params
 
    impure elemental module subroutine update(self, learning_rate)

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -1,68 +1,68 @@
 submodule(nf_layer) nf_layer_submodule
 
-  use nf_conv2d_layer, only: conv2d_layer
-  use nf_dense_layer, only: dense_layer
-  use nf_flatten_layer, only: flatten_layer
-  use nf_input1d_layer, only: input1d_layer
-  use nf_input3d_layer, only: input3d_layer
-  use nf_maxpool2d_layer, only: maxpool2d_layer
-  use nf_reshape_layer, only: reshape3d_layer
+   use nf_conv2d_layer, only: conv2d_layer
+   use nf_dense_layer, only: dense_layer
+   use nf_flatten_layer, only: flatten_layer
+   use nf_input1d_layer, only: input1d_layer
+   use nf_input3d_layer, only: input3d_layer
+   use nf_maxpool2d_layer, only: maxpool2d_layer
+   use nf_reshape_layer, only: reshape3d_layer
 
 contains
 
-  pure module subroutine backward_1d(self, previous, gradient)
-    implicit none
-    class(layer), intent(in out) :: self
-    class(layer), intent(in) :: previous
-    real, intent(in) :: gradient(:)
+   pure module subroutine backward_1d(self, previous, gradient)
+      implicit none
+      class(layer), intent(in out) :: self
+      class(layer), intent(in) :: previous
+      real, intent(in) :: gradient(:)
 
-    ! Backward pass from a 1-d layer downstream currently implemented
-    ! only for dense and flatten layers
-    select type(this_layer => self % p)
+      ! Backward pass from a 1-d layer downstream currently implemented
+      ! only for dense and flatten layers
+      select type(this_layer => self % p)
 
-      type is(dense_layer)
+       type is(dense_layer)
 
-        ! Upstream layers permitted: input1d, dense, flatten
-        select type(prev_layer => previous % p)
+         ! Upstream layers permitted: input1d, dense, flatten
+         select type(prev_layer => previous % p)
           type is(input1d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(dense_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(flatten_layer)
             call this_layer % backward(prev_layer % output, gradient)
-        end select
+         end select
 
-      type is(flatten_layer)
+       type is(flatten_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d
-        select type(prev_layer => previous % p)
+         ! Upstream layers permitted: input3d, conv2d, maxpool2d
+         select type(prev_layer => previous % p)
           type is(input3d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(conv2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(maxpool2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
-        end select
+         end select
 
-    end select
+      end select
 
-  end subroutine backward_1d
+   end subroutine backward_1d
 
 
-  pure module subroutine backward_3d(self, previous, gradient)
-    implicit none
-    class(layer), intent(in out) :: self
-    class(layer), intent(in) :: previous
-    real, intent(in) :: gradient(:,:,:)
+   pure module subroutine backward_3d(self, previous, gradient)
+      implicit none
+      class(layer), intent(in out) :: self
+      class(layer), intent(in) :: previous
+      real, intent(in) :: gradient(:,:,:)
 
-    ! Backward pass from a 3-d layer downstream currently implemented
-    ! only for conv2d and reshape3d layers
-    select type(this_layer => self % p)
+      ! Backward pass from a 3-d layer downstream currently implemented
+      ! only for conv2d and reshape3d layers
+      select type(this_layer => self % p)
 
-      type is(conv2d_layer)
+       type is(conv2d_layer)
 
-        ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
-        select type(prev_layer => previous % p)
+         ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
+         select type(prev_layer => previous % p)
           type is(maxpool2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(input3d_layer)
@@ -71,12 +71,12 @@ contains
             call this_layer % backward(prev_layer % output, gradient)
           type is(reshape3d_layer)
             call this_layer % backward(prev_layer % output, gradient)
-        end select
+         end select
 
-      type is(maxpool2d_layer)
+       type is(maxpool2d_layer)
 
-        ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
-        select type(prev_layer => previous % p)
+         ! Upstream layers permitted: conv2d, input3d, maxpool2d, reshape3d
+         select type(prev_layer => previous % p)
           type is(conv2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(maxpool2d_layer)
@@ -85,48 +85,48 @@ contains
             call this_layer % backward(prev_layer % output, gradient)
           type is(reshape3d_layer)
             call this_layer % backward(prev_layer % output, gradient)
-        end select
+         end select
 
-      type is(reshape3d_layer)
+       type is(reshape3d_layer)
 
-        ! Upstream layers permitted: input1d, dense, flatten
-        select type(prev_layer => previous % p)
+         ! Upstream layers permitted: input1d, dense, flatten
+         select type(prev_layer => previous % p)
           type is(input1d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(dense_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(flatten_layer)
             call this_layer % backward(prev_layer % output, gradient)
-        end select
+         end select
 
-    end select
+      end select
 
-  end subroutine backward_3d
+   end subroutine backward_3d
 
 
-  pure module subroutine forward(self, input)
-    implicit none
-    class(layer), intent(in out) :: self
-    class(layer), intent(in) :: input
+   pure module subroutine forward(self, input)
+      implicit none
+      class(layer), intent(in out) :: self
+      class(layer), intent(in) :: input
 
-    select type(this_layer => self % p)
+      select type(this_layer => self % p)
 
-      type is(dense_layer)
+       type is(dense_layer)
 
-        ! Upstream layers permitted: input1d, dense, flatten
-        select type(prev_layer => input % p)
+         ! Upstream layers permitted: input1d, dense, flatten
+         select type(prev_layer => input % p)
           type is(input1d_layer)
             call this_layer % forward(prev_layer % output)
           type is(dense_layer)
             call this_layer % forward(prev_layer % output)
           type is(flatten_layer)
             call this_layer % forward(prev_layer % output)
-        end select
+         end select
 
-      type is(conv2d_layer)
+       type is(conv2d_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-        select type(prev_layer => input % p)
+         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+         select type(prev_layer => input % p)
           type is(input3d_layer)
             call this_layer % forward(prev_layer % output)
           type is(conv2d_layer)
@@ -135,12 +135,12 @@ contains
             call this_layer % forward(prev_layer % output)
           type is(reshape3d_layer)
             call this_layer % forward(prev_layer % output)
-        end select
+         end select
 
-      type is(maxpool2d_layer)
+       type is(maxpool2d_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-        select type(prev_layer => input % p)
+         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+         select type(prev_layer => input % p)
           type is(input3d_layer)
             call this_layer % forward(prev_layer % output)
           type is(conv2d_layer)
@@ -149,12 +149,12 @@ contains
             call this_layer % forward(prev_layer % output)
           type is(reshape3d_layer)
             call this_layer % forward(prev_layer % output)
-        end select
+         end select
 
-      type is(flatten_layer)
+       type is(flatten_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
-        select type(prev_layer => input % p)
+         ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+         select type(prev_layer => input % p)
           type is(input3d_layer)
             call this_layer % forward(prev_layer % output)
           type is(conv2d_layer)
@@ -163,121 +163,146 @@ contains
             call this_layer % forward(prev_layer % output)
           type is(reshape3d_layer)
             call this_layer % forward(prev_layer % output)
-        end select
+         end select
 
-      type is(reshape3d_layer)
+       type is(reshape3d_layer)
 
-        ! Upstream layers permitted: input1d, dense, flatten
-        select type(prev_layer => input % p)
+         ! Upstream layers permitted: input1d, dense, flatten
+         select type(prev_layer => input % p)
           type is(input1d_layer)
             call this_layer % forward(prev_layer % output)
           type is(dense_layer)
             call this_layer % forward(prev_layer % output)
           type is(flatten_layer)
             call this_layer % forward(prev_layer % output)
-        end select
+         end select
 
-    end select
+      end select
 
-  end subroutine forward
-
-
-  pure module subroutine get_output_1d(self, output)
-    implicit none
-    class(layer), intent(in) :: self
-    real, allocatable, intent(out) :: output(:)
-
-    select type(this_layer => self % p)
-
-      type is(input1d_layer)
-        allocate(output, source=this_layer % output)
-      type is(dense_layer)
-        allocate(output, source=this_layer % output)
-      type is(flatten_layer)
-        allocate(output, source=this_layer % output)
-      class default
-        error stop '1-d output can only be read from an input1d, dense, or flatten layer.'
-
-    end select
-
-  end subroutine get_output_1d
+   end subroutine forward
 
 
-  pure module subroutine get_output_3d(self, output)
-    implicit none
-    class(layer), intent(in) :: self
-    real, allocatable, intent(out) :: output(:,:,:)
+   pure module subroutine get_output_1d(self, output)
+      implicit none
+      class(layer), intent(in) :: self
+      real, allocatable, intent(out) :: output(:)
 
-    select type(this_layer => self % p)
+      select type(this_layer => self % p)
 
-      type is(input3d_layer)
-        allocate(output, source=this_layer % output)
-      type is(conv2d_layer)
-        allocate(output, source=this_layer % output)
-      type is(maxpool2d_layer)
-        allocate(output, source=this_layer % output)
-      type is(reshape3d_layer)
-        allocate(output, source=this_layer % output)
-      class default
-        error stop '3-d output can only be read from a conv2d, input3d, maxpool2d, or reshape3d layer.'
+       type is(input1d_layer)
+         allocate(output, source=this_layer % output)
+       type is(dense_layer)
+         allocate(output, source=this_layer % output)
+       type is(flatten_layer)
+         allocate(output, source=this_layer % output)
+       class default
+         error stop '1-d output can only be read from an input1d, dense, or flatten layer.'
 
-    end select
+      end select
 
-  end subroutine get_output_3d
+   end subroutine get_output_1d
 
 
-  impure elemental module subroutine init(self, input)
-    implicit none
-    class(layer), intent(in out) :: self
-    class(layer), intent(in) :: input
+   pure module subroutine get_output_3d(self, output)
+      implicit none
+      class(layer), intent(in) :: self
+      real, allocatable, intent(out) :: output(:,:,:)
 
-    if (self % initialized) &
-      error stop self % name // ' layer is already initialized.'
+      select type(this_layer => self % p)
 
-    select type(this_layer => self % p); class default
-      call this_layer % init(input % layer_shape)
-    end select
+       type is(input3d_layer)
+         allocate(output, source=this_layer % output)
+       type is(conv2d_layer)
+         allocate(output, source=this_layer % output)
+       type is(maxpool2d_layer)
+         allocate(output, source=this_layer % output)
+       type is(reshape3d_layer)
+         allocate(output, source=this_layer % output)
+       class default
+         error stop '3-d output can only be read from a conv2d, input3d, maxpool2d, or reshape3d layer.'
 
-    ! The shape of conv2d, maxpool2d, or flatten layers is not known
-    ! until we receive an input layer.
-    select type(this_layer => self % p)
-      type is(conv2d_layer)
-        self % layer_shape = shape(this_layer % output)
-      type is(maxpool2d_layer)
-        self % layer_shape = shape(this_layer % output)
-      type is(flatten_layer)
-        self % layer_shape = shape(this_layer % output)
-    end select
+      end select
 
-    self % input_layer_shape = input % layer_shape 
-    self % initialized = .true.
-
-  end subroutine init
+   end subroutine get_output_3d
 
 
-  impure elemental module subroutine print_info(self)
-    implicit none
-    class(layer), intent(in) :: self
-    print '("Layer: ", a)', self % name
-    print '(60("-"))'
-    if (.not. self % name == 'input') &
-      print '("Input shape: ", *(i0, 1x))', self % input_layer_shape
-    print '("Output shape: ", *(i0, 1x))', self % layer_shape
-    if (.not. self % name == 'input') &
-      print '("Activation: ", a)', self % activation
-    print *
-  end subroutine print_info
+   impure elemental module subroutine init(self, input)
+      implicit none
+      class(layer), intent(in out) :: self
+      class(layer), intent(in) :: input
+
+      if (self % initialized) &
+         error stop self % name // ' layer is already initialized.'
+
+      select type(this_layer => self % p); class default
+         call this_layer % init(input % layer_shape)
+      end select
+
+      ! The shape of conv2d, maxpool2d, or flatten layers is not known
+      ! until we receive an input layer.
+      select type(this_layer => self % p)
+       type is(conv2d_layer)
+         self % layer_shape = shape(this_layer % output)
+       type is(maxpool2d_layer)
+         self % layer_shape = shape(this_layer % output)
+       type is(flatten_layer)
+         self % layer_shape = shape(this_layer % output)
+      end select
+
+      self % input_layer_shape = input % layer_shape
+      self % initialized = .true.
+
+   end subroutine init
 
 
-  impure elemental module subroutine update(self, learning_rate)
-    implicit none
-    class(layer), intent(in out) :: self
-    real, intent(in) :: learning_rate
+   impure elemental module subroutine print_info(self)
+      implicit none
+      class(layer), intent(in) :: self
+      print '("Layer: ", a)', self % name
+      print '(60("-"))'
+      if (.not. self % name == 'input') &
+         print '("Input shape: ", *(i0, 1x))', self % input_layer_shape
+      print '("Output shape: ", *(i0, 1x))', self % layer_shape
+      if (.not. self % name == 'input') &
+         print '("Activation: ", a)', self % activation
+      print *
+   end subroutine print_info
 
-    select type(this_layer => self % p); type is(dense_layer)
-      call this_layer % update(learning_rate)
-    end select
+   pure module function get_num_params(self) result(num_params)
+      implicit none
+      class(layer), intent(in) :: self
+      integer :: num_params
 
-  end subroutine update
+      select type(this_layer => self % p)
+       type is(input1d_layer)
+         num_params = 0
+       type is(input3d_layer)
+         num_params = 0
+       type is(dense_layer)
+         num_params = this_layer % get_num_params()
+       type is(conv2d_layer)
+         num_params = this_layer % get_num_params()
+       type is(maxpool2d_layer)
+         num_params = 0
+       type is(flatten_layer)
+         num_params = 0
+       type is(reshape3d_layer)
+         num_params = 0
+       class default
+         error stop 'Unknown layer type.'
+      end select
+
+   end function get_num_params
+
+   impure elemental module subroutine update(self, learning_rate)
+      implicit none
+      class(layer), intent(in out) :: self
+      real, intent(in) :: learning_rate
+
+      select type(this_layer => self % p); type is(dense_layer)
+         call this_layer % update(learning_rate)
+      end select
+
+   end subroutine update
 
 end submodule nf_layer_submodule

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -159,7 +159,7 @@ module nf_network
    end function get_num_params
 
 
-   impure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       !! Get the network parameters (weights and biases).
       class(network), intent(in) :: self
       !! Network instance

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -159,7 +159,7 @@ module nf_network
    end function get_num_params
 
 
-   module subroutine get_parameters(self, params)
+   pure module subroutine get_parameters(self, params)
       !! Get the network parameters (weights and biases).
       class(network), intent(in) :: self
       !! Network instance

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -151,7 +151,7 @@ module nf_network
          !! Network instance
       end subroutine print_info
 
-      module integer function get_num_params(self)
+      pure module integer function get_num_params(self)
       !! Get the number of parameters in the network.
       class(network), intent(in) :: self
       !! Network instance

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -159,7 +159,7 @@ module nf_network
    end function get_num_params
 
 
-   pure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       !! Get the network parameters (weights and biases).
       class(network), intent(in) :: self
       !! Network instance

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -18,6 +18,7 @@ module nf_network
 
       procedure :: backward
       procedure :: get_num_params
+      procedure :: get_parameters
       procedure :: print_info
       procedure :: train
       procedure :: update
@@ -156,6 +157,15 @@ module nf_network
       class(network), intent(in) :: self
       !! Network instance
    end function get_num_params
+
+
+   pure module subroutine get_parameters(self, params)
+      !! Get the network parameters (weights and biases).
+      class(network), intent(in) :: self
+      !! Network instance
+      real, allocatable, intent(inout) :: params(:)
+      !! Network parameters
+   end subroutine get_parameters
 
    module subroutine train(self, input_data, output_data, batch_size, &
       epochs, optimizer)

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -159,7 +159,7 @@ module nf_network
    end function get_num_params
 
 
-   pure module subroutine get_parameters(self, params)
+   impure module subroutine get_parameters(self, params)
       !! Get the network parameters (weights and biases).
       class(network), intent(in) :: self
       !! Network instance

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -167,9 +167,9 @@ module nf_network
       !! Network parameters
         end subroutine get_parameters
 
-        pure module subroutine set_parameters(self, params)
+        module subroutine set_parameters(self, params)
       !! Set the network parameters (weights and biases).
-            class(network), intent(in) :: self
+            class(network), intent(in out) :: self
       !! Network instance
             real, intent(in) :: params(:)
       !! Network parameters

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -1,179 +1,186 @@
 module nf_network
 
-  !! This module provides the network type to create new models.
+   !! This module provides the network type to create new models.
 
-  use nf_layer, only: layer
-  use nf_optimizers, only: sgd
+   use nf_layer, only: layer
+   use nf_optimizers, only: sgd
 
-  implicit none
+   implicit none
 
-  private
-  public :: network
+   private
+   public :: network
 
-  type :: network
+   type :: network
 
-    type(layer), allocatable :: layers(:)
+      type(layer), allocatable :: layers(:)
 
-  contains
+   contains
 
-    procedure :: backward
-    procedure :: print_info
-    procedure :: train
-    procedure :: update
+      procedure :: backward
+      procedure :: get_num_params
+      procedure :: print_info
+      procedure :: train
+      procedure :: update
 
-    procedure, private :: forward_1d
-    procedure, private :: forward_3d
-    procedure, private :: predict_1d
-    procedure, private :: predict_3d
-    procedure, private :: predict_batch_1d
-    procedure, private :: predict_batch_3d
+      procedure, private :: forward_1d
+      procedure, private :: forward_3d
+      procedure, private :: predict_1d
+      procedure, private :: predict_3d
+      procedure, private :: predict_batch_1d
+      procedure, private :: predict_batch_3d
 
-    generic :: forward => forward_1d, forward_3d
-    generic :: predict => predict_1d, predict_3d, predict_batch_1d, predict_batch_3d
+      generic :: forward => forward_1d, forward_3d
+      generic :: predict => predict_1d, predict_3d, predict_batch_1d, predict_batch_3d
 
-  end type network
+   end type network
 
-  interface network
+   interface network
 
-    module function network_from_layers(layers) result(res)
-      !! Create a new `network` instance from an array of `layer` instances.
-      type(layer), intent(in) :: layers(:)
-        !! Input array of `layer` instances;
-        !! the first element must be an input layer.
-      type(network) :: res
-        !! An instance of the `network` type
-    end function network_from_layers
+      module function network_from_layers(layers) result(res)
+         !! Create a new `network` instance from an array of `layer` instances.
+         type(layer), intent(in) :: layers(:)
+         !! Input array of `layer` instances;
+         !! the first element must be an input layer.
+         type(network) :: res
+         !! An instance of the `network` type
+      end function network_from_layers
 
-    module function network_from_keras(filename) result(res)
-      !! Create a new `network` instance
-      !! from a Keras model saved in an h5 file.
-      character(*), intent(in) :: filename
-        !! Path to the Keras model h5 file
-      type(network) :: res
-        !! An instance of the `network` type
-    end function network_from_keras
+      module function network_from_keras(filename) result(res)
+         !! Create a new `network` instance
+         !! from a Keras model saved in an h5 file.
+         character(*), intent(in) :: filename
+         !! Path to the Keras model h5 file
+         type(network) :: res
+         !! An instance of the `network` type
+      end function network_from_keras
 
-  end interface network
+   end interface network
 
-  interface forward
+   interface forward
 
-    pure module subroutine forward_1d(self, input)
-      !! Apply a forward pass through the network.
-      !!
-      !! This changes the state of layers on the network.
-      !! Typically used only internally from the `train` method,
-      !! but can be invoked by the user when creating custom optimizers.
-      !!
-      !! This specific subroutine is for 1-d input data.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:)
-        !! 1-d input data
-    end subroutine forward_1d
+      pure module subroutine forward_1d(self, input)
+         !! Apply a forward pass through the network.
+         !!
+         !! This changes the state of layers on the network.
+         !! Typically used only internally from the `train` method,
+         !! but can be invoked by the user when creating custom optimizers.
+         !!
+         !! This specific subroutine is for 1-d input data.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:)
+         !! 1-d input data
+      end subroutine forward_1d
 
-    pure module subroutine forward_3d(self, input)
-      !! Apply a forward pass through the network.
-      !!
-      !! This changes the state of layers on the network.
-      !! Typically used only internally from the `train` method,
-      !! but can be invoked by the user when creating custom optimizers.
-      !!
-      !! This specific subroutine is for 3-d input data.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:,:,:)
-        !! 3-d input data
-    end subroutine forward_3d
+      pure module subroutine forward_3d(self, input)
+         !! Apply a forward pass through the network.
+         !!
+         !! This changes the state of layers on the network.
+         !! Typically used only internally from the `train` method,
+         !! but can be invoked by the user when creating custom optimizers.
+         !!
+         !! This specific subroutine is for 3-d input data.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:,:,:)
+         !! 3-d input data
+      end subroutine forward_3d
 
-  end interface forward
+   end interface forward
 
-  interface output
+   interface output
 
-    module function predict_1d(self, input) result(res)
-      !! Return the output of the network given the input 1-d array.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:)
-        !! Input data
-      real, allocatable :: res(:)
-        !! Output of the network
-    end function predict_1d
+      module function predict_1d(self, input) result(res)
+         !! Return the output of the network given the input 1-d array.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:)
+         !! Input data
+         real, allocatable :: res(:)
+         !! Output of the network
+      end function predict_1d
 
-    module function predict_3d(self, input) result(res)
-      !! Return the output of the network given the input 3-d array.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:,:,:)
-        !! Input data
-      real, allocatable :: res(:)
-        !! Output of the network
-    end function predict_3d
+      module function predict_3d(self, input) result(res)
+         !! Return the output of the network given the input 3-d array.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:,:,:)
+         !! Input data
+         real, allocatable :: res(:)
+         !! Output of the network
+      end function predict_3d
 
-    module function predict_batch_1d(self, input) result(res)
-      !! Return the output of the network given an input batch of 3-d data.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:,:)
-        !! Input data; the last dimension is the batch
-      real, allocatable :: res(:,:)
-        !! Output of the network; the last dimension is the batch
-    end function predict_batch_1d
+      module function predict_batch_1d(self, input) result(res)
+         !! Return the output of the network given an input batch of 3-d data.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:,:)
+         !! Input data; the last dimension is the batch
+         real, allocatable :: res(:,:)
+         !! Output of the network; the last dimension is the batch
+      end function predict_batch_1d
 
-    module function predict_batch_3d(self, input) result(res)
-      !! Return the output of the network given an input batch of 3-d data.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: input(:,:,:,:)
-        !! Input data; the last dimension is the batch
-      real, allocatable :: res(:,:)
-        !! Output of the network; the last dimension is the batch
-    end function predict_batch_3d
+      module function predict_batch_3d(self, input) result(res)
+         !! Return the output of the network given an input batch of 3-d data.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: input(:,:,:,:)
+         !! Input data; the last dimension is the batch
+         real, allocatable :: res(:,:)
+         !! Output of the network; the last dimension is the batch
+      end function predict_batch_3d
 
-  end interface output
+   end interface output
 
-  interface
+   interface
 
-    pure module subroutine backward(self, output)
-      !! Apply one backward pass through the network.
-      !! This changes the state of layers on the network.
-      !! Typically used only internally from the `train` method,
-      !! but can be invoked by the user when creating custom optimizers.
-      class(network), intent(in out) :: self
-        !! Network instance
-      real, intent(in) :: output(:)
-        !! Output data
-    end subroutine backward
+      pure module subroutine backward(self, output)
+         !! Apply one backward pass through the network.
+         !! This changes the state of layers on the network.
+         !! Typically used only internally from the `train` method,
+         !! but can be invoked by the user when creating custom optimizers.
+         class(network), intent(in out) :: self
+         !! Network instance
+         real, intent(in) :: output(:)
+         !! Output data
+      end subroutine backward
 
-    module subroutine print_info(self)
-      !! Prints a brief summary of the network and its layers to the screen.
+      module subroutine print_info(self)
+         !! Prints a brief summary of the network and its layers to the screen.
+         class(network), intent(in) :: self
+         !! Network instance
+      end subroutine print_info
+
+      module integer function get_num_params(self)
+      !! Get the number of parameters in the network.
       class(network), intent(in) :: self
-        !! Network instance
-    end subroutine print_info
+      !! Network instance
+   end function get_num_params
 
-    module subroutine train(self, input_data, output_data, batch_size, &
-                            epochs, optimizer)
+   module subroutine train(self, input_data, output_data, batch_size, &
+      epochs, optimizer)
       class(network), intent(in out) :: self
-        !! Network instance
+      !! Network instance
       real, intent(in) :: input_data(:,:)
-        !! Input data to train on;
-        !! first dimension contains a single sample
-        !! and its size must match the size of the input layer.
+      !! Input data to train on;
+      !! first dimension contains a single sample
+      !! and its size must match the size of the input layer.
       real, intent(in) :: output_data(:,:)
-        !! Output data to train on;
-        !! first dimension contains a single sample
-        !! and its size must match the size of the input layer.
+      !! Output data to train on;
+      !! first dimension contains a single sample
+      !! and its size must match the size of the input layer.
       integer, intent(in) :: batch_size
-        !! Batch size to use.
-        !! Set to 1 for a pure stochastic gradient descent.
-        !! Set to `size(input_data, dim=2)` for a batch gradient descent.
+      !! Batch size to use.
+      !! Set to 1 for a pure stochastic gradient descent.
+      !! Set to `size(input_data, dim=2)` for a batch gradient descent.
       integer, intent(in) :: epochs
-        !! Number of epochs to run
+      !! Number of epochs to run
       type(sgd), intent(in) :: optimizer
-        !! Optimizer instance; currently this is an `sgd` optimizer type
-        !! and it will be made to be a more general optimizer type.
-    end subroutine train
+      !! Optimizer instance; currently this is an `sgd` optimizer type
+      !! and it will be made to be a more general optimizer type.
+   end subroutine train
 
-    module subroutine update(self, learning_rate)
+   module subroutine update(self, learning_rate)
       !! Update the weights and biases on all layers using the stored
       !! gradients (from backward passes) on those layers, and flush those
       !! same stored gradients to zero.
@@ -181,11 +188,11 @@ module nf_network
       !! Typically used only internally from the `train` method,
       !! but can be invoked by the user when creating custom optimizers.
       class(network), intent(in out) :: self
-        !! Network instance
+      !! Network instance
       real, intent(in) :: learning_rate
-        !! Learning rate to use; must be > 0.
-    end subroutine update
+      !! Learning rate to use; must be > 0.
+   end subroutine update
 
-  end interface
+end interface
 
 end module nf_network

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -2,64 +2,65 @@ module nf_network
 
    !! This module provides the network type to create new models.
 
-   use nf_layer, only: layer
-   use nf_optimizers, only: sgd
+    use nf_layer, only: layer
+    use nf_optimizers, only: sgd
 
-   implicit none
+    implicit none
 
-   private
-   public :: network
+    private
+    public :: network
 
-   type :: network
+    type :: network
 
-      type(layer), allocatable :: layers(:)
+        type(layer), allocatable :: layers(:)
 
-   contains
+    contains
 
-      procedure :: backward
-      procedure :: get_num_params
-      procedure :: get_parameters
-      procedure :: print_info
-      procedure :: train
-      procedure :: update
+        procedure :: backward
+        procedure :: get_num_params
+        procedure :: get_parameters
+        procedure :: set_parameters
+        procedure :: print_info
+        procedure :: train
+        procedure :: update
 
-      procedure, private :: forward_1d
-      procedure, private :: forward_3d
-      procedure, private :: predict_1d
-      procedure, private :: predict_3d
-      procedure, private :: predict_batch_1d
-      procedure, private :: predict_batch_3d
+        procedure, private :: forward_1d
+        procedure, private :: forward_3d
+        procedure, private :: predict_1d
+        procedure, private :: predict_3d
+        procedure, private :: predict_batch_1d
+        procedure, private :: predict_batch_3d
 
-      generic :: forward => forward_1d, forward_3d
-      generic :: predict => predict_1d, predict_3d, predict_batch_1d, predict_batch_3d
+        generic :: forward => forward_1d, forward_3d
+        generic :: predict => predict_1d, predict_3d, predict_batch_1d, predict_batch_3d
 
-   end type network
+    end type network
 
-   interface network
+    interface network
 
-      module function network_from_layers(layers) result(res)
+        module function network_from_layers(layers) result(res)
          !! Create a new `network` instance from an array of `layer` instances.
-         type(layer), intent(in) :: layers(:)
+            type(layer), intent(in) :: layers(:)
          !! Input array of `layer` instances;
          !! the first element must be an input layer.
-         type(network) :: res
+            type(network) :: res
          !! An instance of the `network` type
-      end function network_from_layers
+        end function network_from_layers
 
-      module function network_from_keras(filename) result(res)
+        module function network_from_keras(filename) result(res)
          !! Create a new `network` instance
          !! from a Keras model saved in an h5 file.
-         character(*), intent(in) :: filename
+            character(*), intent(in) :: filename
          !! Path to the Keras model h5 file
-         type(network) :: res
+            type(network) :: res
          !! An instance of the `network` type
-      end function network_from_keras
+        end function network_from_keras
 
-   end interface network
+    end interface network
 
-   interface forward
+    interface forward
 
-      pure module subroutine forward_1d(self, input)
+        pure module subroutine forward_1d(self, input)
          !! Apply a forward pass through the network.
          !!
          !! This changes the state of layers on the network.
@@ -67,13 +68,13 @@ module nf_network
          !! but can be invoked by the user when creating custom optimizers.
          !!
          !! This specific subroutine is for 1-d input data.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:)
+            real, intent(in) :: input(:)
          !! 1-d input data
-      end subroutine forward_1d
+        end subroutine forward_1d
 
-      pure module subroutine forward_3d(self, input)
+        pure module subroutine forward_3d(self, input)
          !! Apply a forward pass through the network.
          !!
          !! This changes the state of layers on the network.
@@ -81,128 +82,135 @@ module nf_network
          !! but can be invoked by the user when creating custom optimizers.
          !!
          !! This specific subroutine is for 3-d input data.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:,:,:)
+            real, intent(in) :: input(:, :, :)
          !! 3-d input data
-      end subroutine forward_3d
+        end subroutine forward_3d
 
-   end interface forward
+    end interface forward
 
-   interface output
+    interface output
 
-      module function predict_1d(self, input) result(res)
+        module function predict_1d(self, input) result(res)
          !! Return the output of the network given the input 1-d array.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:)
+            real, intent(in) :: input(:)
          !! Input data
-         real, allocatable :: res(:)
+            real, allocatable :: res(:)
          !! Output of the network
-      end function predict_1d
+        end function predict_1d
 
-      module function predict_3d(self, input) result(res)
+        module function predict_3d(self, input) result(res)
          !! Return the output of the network given the input 3-d array.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:,:,:)
+            real, intent(in) :: input(:, :, :)
          !! Input data
-         real, allocatable :: res(:)
+            real, allocatable :: res(:)
          !! Output of the network
-      end function predict_3d
+        end function predict_3d
 
-      module function predict_batch_1d(self, input) result(res)
+        module function predict_batch_1d(self, input) result(res)
          !! Return the output of the network given an input batch of 3-d data.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:,:)
+            real, intent(in) :: input(:, :)
          !! Input data; the last dimension is the batch
-         real, allocatable :: res(:,:)
+            real, allocatable :: res(:, :)
          !! Output of the network; the last dimension is the batch
-      end function predict_batch_1d
+        end function predict_batch_1d
 
-      module function predict_batch_3d(self, input) result(res)
+        module function predict_batch_3d(self, input) result(res)
          !! Return the output of the network given an input batch of 3-d data.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: input(:,:,:,:)
+            real, intent(in) :: input(:, :, :, :)
          !! Input data; the last dimension is the batch
-         real, allocatable :: res(:,:)
+            real, allocatable :: res(:, :)
          !! Output of the network; the last dimension is the batch
-      end function predict_batch_3d
+        end function predict_batch_3d
 
-   end interface output
+    end interface output
 
-   interface
+    interface
 
-      pure module subroutine backward(self, output)
+        pure module subroutine backward(self, output)
          !! Apply one backward pass through the network.
          !! This changes the state of layers on the network.
          !! Typically used only internally from the `train` method,
          !! but can be invoked by the user when creating custom optimizers.
-         class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
          !! Network instance
-         real, intent(in) :: output(:)
+            real, intent(in) :: output(:)
          !! Output data
-      end subroutine backward
+        end subroutine backward
 
-      module subroutine print_info(self)
+        module subroutine print_info(self)
          !! Prints a brief summary of the network and its layers to the screen.
-         class(network), intent(in) :: self
+            class(network), intent(in) :: self
          !! Network instance
-      end subroutine print_info
+        end subroutine print_info
 
-      pure module integer function get_num_params(self)
+        pure module integer function get_num_params(self)
       !! Get the number of parameters in the network.
-      class(network), intent(in) :: self
+            class(network), intent(in) :: self
       !! Network instance
-   end function get_num_params
+        end function get_num_params
 
-
-   pure module subroutine get_parameters(self, params)
+        pure module subroutine get_parameters(self, params)
       !! Get the network parameters (weights and biases).
-      class(network), intent(in) :: self
+            class(network), intent(in) :: self
       !! Network instance
-      real, allocatable, intent(inout) :: params(:)
+            real, allocatable, intent(inout) :: params(:)
       !! Network parameters
-   end subroutine get_parameters
+        end subroutine get_parameters
 
-   module subroutine train(self, input_data, output_data, batch_size, &
-      epochs, optimizer)
-      class(network), intent(in out) :: self
+        pure module subroutine set_parameters(self, params)
+      !! Set the network parameters (weights and biases).
+            class(network), intent(in) :: self
       !! Network instance
-      real, intent(in) :: input_data(:,:)
+            real, intent(in) :: params(:)
+      !! Network parameters
+        end subroutine set_parameters
+
+        module subroutine train(self, input_data, output_data, batch_size, &
+                                epochs, optimizer)
+            class(network), intent(in out) :: self
+      !! Network instance
+            real, intent(in) :: input_data(:, :)
       !! Input data to train on;
       !! first dimension contains a single sample
       !! and its size must match the size of the input layer.
-      real, intent(in) :: output_data(:,:)
+            real, intent(in) :: output_data(:, :)
       !! Output data to train on;
       !! first dimension contains a single sample
       !! and its size must match the size of the input layer.
-      integer, intent(in) :: batch_size
+            integer, intent(in) :: batch_size
       !! Batch size to use.
       !! Set to 1 for a pure stochastic gradient descent.
       !! Set to `size(input_data, dim=2)` for a batch gradient descent.
-      integer, intent(in) :: epochs
+            integer, intent(in) :: epochs
       !! Number of epochs to run
-      type(sgd), intent(in) :: optimizer
+            type(sgd), intent(in) :: optimizer
       !! Optimizer instance; currently this is an `sgd` optimizer type
       !! and it will be made to be a more general optimizer type.
-   end subroutine train
+        end subroutine train
 
-   module subroutine update(self, learning_rate)
+        module subroutine update(self, learning_rate)
       !! Update the weights and biases on all layers using the stored
       !! gradients (from backward passes) on those layers, and flush those
       !! same stored gradients to zero.
       !! This changes the state of layers on the network.
       !! Typically used only internally from the `train` method,
       !! but can be invoked by the user when creating custom optimizers.
-      class(network), intent(in out) :: self
+            class(network), intent(in out) :: self
       !! Network instance
-      real, intent(in) :: learning_rate
+            real, intent(in) :: learning_rate
       !! Learning rate to use; must be > 0.
-   end subroutine update
+        end subroutine update
 
-end interface
+    end interface
 
 end module nf_network

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -383,6 +383,10 @@ contains
       class(network), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
       integer :: n
+
+      do n = 1, size(self % layers)
+         call self % layers(n) % get_parameters(params)
+      end do
    end subroutine get_parameters
 
    module subroutine train(self, input_data, output_data, batch_size, &

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -379,6 +379,12 @@ contains
       end do
    end function get_num_params
 
+   pure module subroutine get_parameters(self, params)
+      class(network), intent(in) :: self
+      real, allocatable, intent(inout) :: params(:)
+      integer :: n
+   end subroutine get_parameters
+
    module subroutine train(self, input_data, output_data, batch_size, &
       epochs, optimizer)
       class(network), intent(in out) :: self

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -1,445 +1,440 @@
 submodule(nf_network) nf_network_submodule
 
-   use nf_conv2d_layer, only: conv2d_layer
-   use nf_dense_layer, only: dense_layer
-   use nf_flatten_layer, only: flatten_layer
-   use nf_input1d_layer, only: input1d_layer
-   use nf_input3d_layer, only: input3d_layer
-   use nf_maxpool2d_layer, only: maxpool2d_layer
-   use nf_reshape_layer, only: reshape3d_layer
-   use nf_io_hdf5, only: get_hdf5_dataset
-   use nf_keras, only: get_keras_h5_layers, keras_layer
-   use nf_layer, only: layer
-   use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
-   use nf_loss, only: quadratic_derivative
-   use nf_optimizers, only: sgd
-   use nf_parallel, only: tile_indices
+    use nf_conv2d_layer, only: conv2d_layer
+    use nf_dense_layer, only: dense_layer
+    use nf_flatten_layer, only: flatten_layer
+    use nf_input1d_layer, only: input1d_layer
+    use nf_input3d_layer, only: input3d_layer
+    use nf_maxpool2d_layer, only: maxpool2d_layer
+    use nf_reshape_layer, only: reshape3d_layer
+    use nf_io_hdf5, only: get_hdf5_dataset
+    use nf_keras, only: get_keras_h5_layers, keras_layer
+    use nf_layer, only: layer
+    use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
+    use nf_loss, only: quadratic_derivative
+    use nf_optimizers, only: sgd
+    use nf_parallel, only: tile_indices
 
-   implicit none
+    implicit none
 
 contains
 
-   module function network_from_layers(layers) result(res)
-      type(layer), intent(in) :: layers(:)
-      type(network) :: res
-      integer :: n
+    module function network_from_layers(layers) result(res)
+        type(layer), intent(in) :: layers(:)
+        type(network) :: res
+        integer :: n
 
-      ! Error handling
+        ! Error handling
 
-      ! There must be at least two layers
-      if (size(layers) < 2) &
-         error stop 'Error: A network must have at least 2 layers.'
+        ! There must be at least two layers
+        if (size(layers) < 2) &
+            error stop 'Error: A network must have at least 2 layers.'
 
-      ! The first layer must be an input layer
-      if (.not. layers(1) % name == 'input') &
-         error stop 'Error: First layer in the network must be an input layer.'
+        ! The first layer must be an input layer
+        if (.not. layers(1)%name == 'input') &
+            error stop 'Error: First layer in the network must be an input layer.'
 
-      !TODO Ensure that the layers are in allowed sequence:
-      !TODO   input1d -> dense
-      !TODO   dense -> dense
-      !TODO   input3d -> conv2d, maxpool2d, flatten
-      !TODO   conv2d -> conv2d, maxpool2d, flatten
-      !TODO   maxpool2d -> conv2d, maxpool2d, flatten
-      !TODO   flatten -> dense
-      !TODO   reshape -> conv2d, maxpool2d
+        !TODO Ensure that the layers are in allowed sequence:
+        !TODO   input1d -> dense
+        !TODO   dense -> dense
+        !TODO   input3d -> conv2d, maxpool2d, flatten
+        !TODO   conv2d -> conv2d, maxpool2d, flatten
+        !TODO   maxpool2d -> conv2d, maxpool2d, flatten
+        !TODO   flatten -> dense
+        !TODO   reshape -> conv2d, maxpool2d
 
-      res % layers = layers
+        res%layers = layers
 
-      ! Loop over each layer in order and call the init methods.
-      ! This will allocate the data internal to each layer (e.g. weights, biases)
-      ! according to the size of the previous layer.
-      do n = 2, size(layers)
-         call res % layers(n) % init(res % layers(n - 1))
-      end do
+        ! Loop over each layer in order and call the init methods.
+        ! This will allocate the data internal to each layer (e.g. weights, biases)
+        ! according to the size of the previous layer.
+        do n = 2, size(layers)
+            call res%layers(n)%init(res%layers(n - 1))
+        end do
 
-   end function network_from_layers
+    end function network_from_layers
 
+    module function network_from_keras(filename) result(res)
+        character(*), intent(in) :: filename
+        type(network) :: res
+        type(keras_layer), allocatable :: keras_layers(:)
+        type(layer), allocatable :: layers(:)
+        character(:), allocatable :: layer_name
+        character(:), allocatable :: object_name
+        integer :: n
 
-   module function network_from_keras(filename) result(res)
-      character(*), intent(in) :: filename
-      type(network) :: res
-      type(keras_layer), allocatable :: keras_layers(:)
-      type(layer), allocatable :: layers(:)
-      character(:), allocatable :: layer_name
-      character(:), allocatable :: object_name
-      integer :: n
+        keras_layers = get_keras_h5_layers(filename)
 
-      keras_layers = get_keras_h5_layers(filename)
+        allocate (layers(size(keras_layers)))
 
-      allocate(layers(size(keras_layers)))
+        do n = 1, size(layers)
 
-      do n = 1, size(layers)
+            select case (keras_layers(n)%class)
 
-         select case(keras_layers(n) % class)
+            case ('Conv2D')
 
-          case('Conv2D')
+                if (keras_layers(n)%kernel_size(1) &
+                    /= keras_layers(n)%kernel_size(2)) &
+                    error stop 'Non-square kernel in conv2d layer not supported.'
 
-            if (keras_layers(n) % kernel_size(1) &
-               /= keras_layers(n) % kernel_size(2)) &
-               error stop 'Non-square kernel in conv2d layer not supported.'
+                layers(n) = conv2d( &
+                            keras_layers(n)%filters, &
+                            !FIXME add support for non-square kernel
+                            keras_layers(n)%kernel_size(1), &
+                            keras_layers(n)%activation &
+                            )
 
-            layers(n) = conv2d( &
-               keras_layers(n) % filters, &
-            !FIXME add support for non-square kernel
-               keras_layers(n) % kernel_size(1), &
-               keras_layers(n) % activation &
-               )
+            case ('Dense')
+                layers(n) = dense( &
+                            keras_layers(n)%units(1), &
+                            keras_layers(n)%activation &
+                            )
 
-          case('Dense')
-            layers(n) = dense( &
-               keras_layers(n) % units(1), &
-               keras_layers(n) % activation &
-               )
+            case ('Flatten')
+                layers(n) = flatten()
 
-          case('Flatten')
-            layers(n) = flatten()
+            case ('InputLayer')
+                if (size(keras_layers(n)%units) == 1) then
+                    ! input1d
+                    layers(n) = input(keras_layers(n)%units(1))
+                else
+                    ! input3d
+                    layers(n) = input(keras_layers(n)%units)
+                end if
 
-          case('InputLayer')
-            if (size(keras_layers(n) % units) == 1) then
-               ! input1d
-               layers(n) = input(keras_layers(n) % units(1))
+            case ('MaxPooling2D')
+
+                if (keras_layers(n)%pool_size(1) &
+                    /= keras_layers(n)%pool_size(2)) &
+                    error stop 'Non-square pool in maxpool2d layer not supported.'
+
+                if (keras_layers(n)%strides(1) &
+                    /= keras_layers(n)%strides(2)) &
+                    error stop 'Unequal strides in maxpool2d layer are not supported.'
+
+                layers(n) = maxpool2d( &
+                            !FIXME add support for non-square pool and stride
+                            keras_layers(n)%pool_size(1), &
+                            keras_layers(n)%strides(1) &
+                            )
+
+            case ('Reshape')
+                layers(n) = reshape(keras_layers(n)%target_shape)
+
+            case default
+                error stop 'This Keras layer is not supported'
+
+            end select
+
+        end do
+
+        res = network(layers)
+
+        ! Loop over layers and read weights and biases from the Keras h5 file
+        ! for each; currently only dense layers are implemented.
+        do n = 2, size(res%layers)
+
+            layer_name = keras_layers(n)%name
+
+            select type (this_layer => res%layers(n)%p)
+
+            type is (conv2d_layer)
+                ! Read biases from file
+                object_name = '/model_weights/'//layer_name//'/' &
+                              //layer_name//'/bias:0'
+                call get_hdf5_dataset(filename, object_name, this_layer%biases)
+
+                ! Read weights from file
+                object_name = '/model_weights/'//layer_name//'/' &
+                              //layer_name//'/kernel:0'
+                call get_hdf5_dataset(filename, object_name, this_layer%kernel)
+
+            type is (dense_layer)
+
+                ! Read biases from file
+                object_name = '/model_weights/'//layer_name//'/' &
+                              //layer_name//'/bias:0'
+                call get_hdf5_dataset(filename, object_name, this_layer%biases)
+
+                ! Read weights from file
+                object_name = '/model_weights/'//layer_name//'/' &
+                              //layer_name//'/kernel:0'
+                call get_hdf5_dataset(filename, object_name, this_layer%weights)
+
+            type is (flatten_layer)
+                ! Nothing to do
+                continue
+
+            type is (maxpool2d_layer)
+                ! Nothing to do
+                continue
+
+            type is (reshape3d_layer)
+                ! Nothing to do
+                continue
+
+            class default
+                error stop 'Internal error in network_from_keras(); ' &
+                    //'mismatch in layer types between the Keras and ' &
+                    //'neural-fortran model layers.'
+
+            end select
+
+        end do
+
+    end function network_from_keras
+
+    pure module subroutine backward(self, output)
+        class(network), intent(in out) :: self
+        real, intent(in) :: output(:)
+        real, allocatable :: gradient(:)
+        integer :: n, num_layers
+
+        num_layers = size(self%layers)
+
+        ! Iterate backward over layers, from the output layer
+        ! to the first non-input layer
+        do n = num_layers, 2, -1
+
+            if (n == num_layers) then
+                ! Output layer; apply the loss function
+                select type (this_layer => self%layers(n)%p)
+                type is (dense_layer)
+                    gradient = quadratic_derivative(output, this_layer%output)
+                end select
             else
-               ! input3d
-               layers(n) = input(keras_layers(n) % units)
+                ! Hidden layer; take the gradient from the next layer
+                select type (next_layer => self%layers(n + 1)%p)
+                type is (dense_layer)
+                    gradient = next_layer%gradient
+                end select
             end if
 
-          case('MaxPooling2D')
+            call self%layers(n)%backward(self%layers(n - 1), gradient)
 
-            if (keras_layers(n) % pool_size(1) &
-               /= keras_layers(n) % pool_size(2)) &
-               error stop 'Non-square pool in maxpool2d layer not supported.'
+        end do
 
-            if (keras_layers(n) % strides(1) &
-               /= keras_layers(n) % strides(2)) &
-               error stop 'Unequal strides in maxpool2d layer are not supported.'
+    end subroutine backward
 
-            layers(n) = maxpool2d( &
-            !FIXME add support for non-square pool and stride
-               keras_layers(n) % pool_size(1), &
-               keras_layers(n) % strides(1) &
-               )
+    pure module subroutine forward_1d(self, input)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:)
+        integer :: n
 
-          case('Reshape')
-            layers(n) = reshape(keras_layers(n) % target_shape)
+        ! Set the input array into the input layer
+        select type (input_layer => self%layers(1)%p); type is (input1d_layer)
+            call input_layer%set(input)
+        end select
 
-          case default
-            error stop 'This Keras layer is not supported'
+        do n = 2, size(self%layers)
+            call self%layers(n)%forward(self%layers(n - 1))
+        end do
 
-         end select
+    end subroutine forward_1d
 
-      end do
+    pure module subroutine forward_3d(self, input)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:, :, :)
+        integer :: n
 
-      res = network(layers)
+        ! Set the input array into the input layer
+        select type (input_layer => self%layers(1)%p); type is (input3d_layer)
+            call input_layer%set(input)
+        end select
 
-      ! Loop over layers and read weights and biases from the Keras h5 file
-      ! for each; currently only dense layers are implemented.
-      do n = 2, size(res % layers)
+        do n = 2, size(self%layers)
+            call self%layers(n)%forward(self%layers(n - 1))
+        end do
 
-         layer_name = keras_layers(n) % name
+    end subroutine forward_3d
 
-         select type(this_layer => res % layers(n) % p)
+    module function predict_1d(self, input) result(res)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:)
+        real, allocatable :: res(:)
+        integer :: num_layers
 
-          type is(conv2d_layer)
-            ! Read biases from file
-            object_name = '/model_weights/' // layer_name // '/' &
-               // layer_name // '/bias:0'
-            call get_hdf5_dataset(filename, object_name, this_layer % biases)
+        num_layers = size(self%layers)
 
-            ! Read weights from file
-            object_name = '/model_weights/' // layer_name // '/' &
-               // layer_name // '/kernel:0'
-            call get_hdf5_dataset(filename, object_name, this_layer % kernel)
+        call self%forward(input)
 
-          type is(dense_layer)
-
-            ! Read biases from file
-            object_name = '/model_weights/' // layer_name // '/' &
-               // layer_name // '/bias:0'
-            call get_hdf5_dataset(filename, object_name, this_layer % biases)
-
-            ! Read weights from file
-            object_name = '/model_weights/' // layer_name // '/' &
-               // layer_name // '/kernel:0'
-            call get_hdf5_dataset(filename, object_name, this_layer % weights)
-
-          type is(flatten_layer)
-            ! Nothing to do
-            continue
-
-          type is(maxpool2d_layer)
-            ! Nothing to do
-            continue
-
-          type is(reshape3d_layer)
-            ! Nothing to do
-            continue
-
-          class default
-            error stop 'Internal error in network_from_keras(); ' &
-               // 'mismatch in layer types between the Keras and ' &
-               // 'neural-fortran model layers.'
-
-         end select
-
-      end do
-
-   end function network_from_keras
-
-
-   pure module subroutine backward(self, output)
-      class(network), intent(in out) :: self
-      real, intent(in) :: output(:)
-      real, allocatable :: gradient(:)
-      integer :: n, num_layers
-
-      num_layers = size(self % layers)
-
-      ! Iterate backward over layers, from the output layer
-      ! to the first non-input layer
-      do n = num_layers, 2, -1
-
-         if (n == num_layers) then
-            ! Output layer; apply the loss function
-            select type(this_layer => self % layers(n) % p)
-             type is(dense_layer)
-               gradient = quadratic_derivative(output, this_layer % output)
-            end select
-         else
-            ! Hidden layer; take the gradient from the next layer
-            select type(next_layer => self % layers(n + 1) % p)
-             type is(dense_layer)
-               gradient = next_layer % gradient
-            end select
-         end if
-
-         call self % layers(n) % backward(self % layers(n - 1), gradient)
-
-      end do
-
-   end subroutine backward
-
-
-   pure module subroutine forward_1d(self, input)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:)
-      integer :: n
-
-      ! Set the input array into the input layer
-      select type(input_layer => self % layers(1) % p); type is(input1d_layer)
-         call input_layer % set(input)
-      end select
-
-      do n = 2, size(self % layers)
-         call self % layers(n) % forward(self % layers(n - 1))
-      end do
-
-   end subroutine forward_1d
-
-
-   pure module subroutine forward_3d(self, input)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:,:,:)
-      integer :: n
-
-      ! Set the input array into the input layer
-      select type(input_layer => self % layers(1) % p); type is(input3d_layer)
-         call input_layer % set(input)
-      end select
-
-      do n = 2, size(self % layers)
-         call self % layers(n) % forward(self % layers(n - 1))
-      end do
-
-   end subroutine forward_3d
-
-
-   module function predict_1d(self, input) result(res)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:)
-      real, allocatable :: res(:)
-      integer :: num_layers
-
-      num_layers = size(self % layers)
-
-      call self % forward(input)
-
-      select type(output_layer => self % layers(num_layers) % p)
-       type is(dense_layer)
-         res = output_layer % output
-       type is(flatten_layer)
-         res = output_layer % output
-       class default
-         error stop 'network % output not implemented for this output layer'
-      end select
-
-   end function predict_1d
-
-
-   module function predict_3d(self, input) result(res)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:,:,:)
-      real, allocatable :: res(:)
-      integer :: num_layers
-
-      num_layers = size(self % layers)
-
-      call self % forward(input)
-
-      select type(output_layer => self % layers(num_layers) % p)
-       type is(conv2d_layer)
-         !FIXME flatten the result for now; find a better solution
-         res = pack(output_layer % output, .true.)
-       type is(dense_layer)
-         res = output_layer % output
-       type is(flatten_layer)
-         res = output_layer % output
-       class default
-         error stop 'network % output not implemented for this output layer'
-      end select
-
-   end function predict_3d
-
-
-   module function predict_batch_1d(self, input) result(res)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:,:)
-      real, allocatable :: res(:,:)
-      integer :: i, batch_size, num_layers, output_size
-
-      num_layers = size(self % layers)
-      batch_size = size(input, dim=rank(input))
-      output_size = product(self % layers(num_layers) % layer_shape)
-
-      allocate(res(output_size, batch_size))
-
-      batch: do concurrent(i = 1:size(res, dim=2))
-
-         call self % forward(input(:,i))
-
-         select type(output_layer => self % layers(num_layers) % p)
-          type is(dense_layer)
-            res(:,i) = output_layer % output
-          type is(flatten_layer)
-            res(:,i) = output_layer % output
-          class default
+        select type (output_layer => self%layers(num_layers)%p)
+        type is (dense_layer)
+            res = output_layer%output
+        type is (flatten_layer)
+            res = output_layer%output
+        class default
             error stop 'network % output not implemented for this output layer'
-         end select
+        end select
 
-      end do batch
+    end function predict_1d
 
-   end function predict_batch_1d
+    module function predict_3d(self, input) result(res)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:, :, :)
+        real, allocatable :: res(:)
+        integer :: num_layers
 
+        num_layers = size(self%layers)
 
-   module function predict_batch_3d(self, input) result(res)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input(:,:,:,:)
-      real, allocatable :: res(:,:)
-      integer :: i, batch_size, num_layers, output_size
+        call self%forward(input)
 
-      num_layers = size(self % layers)
-      batch_size = size(input, dim=rank(input))
-      output_size = product(self % layers(num_layers) % layer_shape)
-
-      allocate(res(output_size, batch_size))
-
-      batch: do concurrent(i = 1:batch_size)
-
-         call self % forward(input(:,:,:,i))
-
-         select type(output_layer => self % layers(num_layers) % p)
-          type is(conv2d_layer)
+        select type (output_layer => self%layers(num_layers)%p)
+        type is (conv2d_layer)
             !FIXME flatten the result for now; find a better solution
-            res(:,i) = pack(output_layer % output, .true.)
-          type is(dense_layer)
-            res(:,i) = output_layer % output
-          type is(flatten_layer)
-            res(:,i) = output_layer % output
-          class default
+            res = pack(output_layer%output, .true.)
+        type is (dense_layer)
+            res = output_layer%output
+        type is (flatten_layer)
+            res = output_layer%output
+        class default
             error stop 'network % output not implemented for this output layer'
-         end select
+        end select
 
-      end do batch
+    end function predict_3d
 
-   end function predict_batch_3d
+    module function predict_batch_1d(self, input) result(res)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:, :)
+        real, allocatable :: res(:, :)
+        integer :: i, batch_size, num_layers, output_size
 
+        num_layers = size(self%layers)
+        batch_size = size(input, dim=rank(input))
+        output_size = product(self%layers(num_layers)%layer_shape)
 
-   module subroutine print_info(self)
-      class(network), intent(in) :: self
-      call self % layers % print_info()
-   end subroutine print_info
+        allocate (res(output_size, batch_size))
 
-   pure module function get_num_params(self) result(num_params)
-      class(network), intent(in) :: self
-      integer :: n, num_params
+        batch: do concurrent(i=1:size(res, dim=2))
 
-      num_params = 0
+            call self%forward(input(:, i))
 
-      do n = 1, size(self % layers)
-         num_params = num_params +  self % layers(n) % get_num_params()
-      end do
-   end function get_num_params
+            select type (output_layer => self%layers(num_layers)%p)
+            type is (dense_layer)
+                res(:, i) = output_layer%output
+            type is (flatten_layer)
+                res(:, i) = output_layer%output
+            class default
+                error stop 'network % output not implemented for this output layer'
+            end select
 
-   pure module subroutine get_parameters(self, params)
-      class(network), intent(in) :: self
-      real, allocatable, intent(inout) :: params(:)
-      integer :: n
+        end do batch
 
-      do n = 1, size(self % layers)
-         call self % layers(n) % get_parameters(params)
-      end do
-   end subroutine get_parameters
+    end function predict_batch_1d
 
-   module subroutine train(self, input_data, output_data, batch_size, &
-      epochs, optimizer)
-      class(network), intent(in out) :: self
-      real, intent(in) :: input_data(:,:)
-      real, intent(in) :: output_data(:,:)
-      integer, intent(in) :: batch_size
-      integer, intent(in) :: epochs
-      type(sgd), intent(in) :: optimizer
+    module function predict_batch_3d(self, input) result(res)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input(:, :, :, :)
+        real, allocatable :: res(:, :)
+        integer :: i, batch_size, num_layers, output_size
 
-      real :: pos
-      integer :: dataset_size
-      integer :: batch_start, batch_end
-      integer :: i, j, n
-      integer :: istart, iend, indices(2)
+        num_layers = size(self%layers)
+        batch_size = size(input, dim=rank(input))
+        output_size = product(self%layers(num_layers)%layer_shape)
 
-      dataset_size = size(output_data, dim=2)
+        allocate (res(output_size, batch_size))
 
-      epoch_loop: do n = 1, epochs
-         batch_loop: do i = 1, dataset_size / batch_size
+        batch: do concurrent(i=1:batch_size)
 
-            ! Pull a random mini-batch from the dataset
-            call random_number(pos)
-            batch_start = int(pos * (dataset_size - batch_size + 1)) + 1
-            batch_end = batch_start + batch_size - 1
+            call self%forward(input(:, :, :, i))
 
-            ! FIXME shuffle in a way that doesn't require co_broadcast
-            call co_broadcast(batch_start, 1)
-            call co_broadcast(batch_end, 1)
+            select type (output_layer => self%layers(num_layers)%p)
+            type is (conv2d_layer)
+                !FIXME flatten the result for now; find a better solution
+                res(:, i) = pack(output_layer%output, .true.)
+            type is (dense_layer)
+                res(:, i) = output_layer%output
+            type is (flatten_layer)
+                res(:, i) = output_layer%output
+            class default
+                error stop 'network % output not implemented for this output layer'
+            end select
 
-            ! Distribute the batch in nearly equal pieces to all images
-            indices = tile_indices(batch_size)
-            istart = indices(1) + batch_start - 1
-            iend = indices(2) + batch_start - 1
+        end do batch
 
-            do concurrent(j = istart:iend)
-               call self % forward(input_data(:,j))
-               call self % backward(output_data(:,j))
-            end do
+    end function predict_batch_3d
 
-            call self % update(optimizer % learning_rate / batch_size)
+    module subroutine print_info(self)
+        class(network), intent(in) :: self
+        call self%layers%print_info()
+    end subroutine print_info
 
-         end do batch_loop
-      end do epoch_loop
+    pure module function get_num_params(self) result(num_params)
+        class(network), intent(in) :: self
+        integer :: n, num_params
 
-   end subroutine train
+        num_params = 0
 
+        do n = 1, size(self%layers)
+            num_params = num_params + self%layers(n)%get_num_params()
+        end do
+    end function get_num_params
 
-   module subroutine update(self, learning_rate)
-      class(network), intent(in out) :: self
-      real, intent(in) :: learning_rate
-      call self % layers % update(learning_rate)
-   end subroutine update
+    pure module subroutine get_parameters(self, params)
+        class(network), intent(in) :: self
+        real, allocatable, intent(inout) :: params(:)
+        integer :: n
+
+        do n = 1, size(self%layers)
+            call self%layers(n)%get_parameters(params)
+        end do
+    end subroutine get_parameters
+
+    pure module subroutine set_parameters(self, params)
+        class(network), intent(in) :: self
+        real, intent(in) :: params(:)
+    end subroutine set_parameters
+
+    module subroutine train(self, input_data, output_data, batch_size, &
+                            epochs, optimizer)
+        class(network), intent(in out) :: self
+        real, intent(in) :: input_data(:, :)
+        real, intent(in) :: output_data(:, :)
+        integer, intent(in) :: batch_size
+        integer, intent(in) :: epochs
+        type(sgd), intent(in) :: optimizer
+
+        real :: pos
+        integer :: dataset_size
+        integer :: batch_start, batch_end
+        integer :: i, j, n
+        integer :: istart, iend, indices(2)
+
+        dataset_size = size(output_data, dim=2)
+
+        epoch_loop: do n = 1, epochs
+            batch_loop: do i = 1, dataset_size/batch_size
+
+                ! Pull a random mini-batch from the dataset
+                call random_number(pos)
+                batch_start = int(pos*(dataset_size - batch_size + 1)) + 1
+                batch_end = batch_start + batch_size - 1
+
+                ! FIXME shuffle in a way that doesn't require co_broadcast
+                call co_broadcast(batch_start, 1)
+                call co_broadcast(batch_end, 1)
+
+                ! Distribute the batch in nearly equal pieces to all images
+                indices = tile_indices(batch_size)
+                istart = indices(1) + batch_start - 1
+                iend = indices(2) + batch_start - 1
+
+                do concurrent(j=istart:iend)
+                    call self%forward(input_data(:, j))
+                    call self%backward(output_data(:, j))
+                end do
+
+                call self%update(optimizer%learning_rate/batch_size)
+
+            end do batch_loop
+        end do epoch_loop
+
+    end subroutine train
+
+    module subroutine update(self, learning_rate)
+        class(network), intent(in out) :: self
+        real, intent(in) :: learning_rate
+        call self%layers%update(learning_rate)
+    end subroutine update
 
 end submodule nf_network_submodule

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -368,7 +368,7 @@ contains
       call self % layers % print_info()
    end subroutine print_info
 
-   module integer function get_num_params(self)
+   pure module integer function get_num_params(self)
    class(network), intent(in) :: self
    !call self % layers % print_info()
    ! get_num_params = self % layers % get_num_params()

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -379,7 +379,7 @@ contains
       end do
    end function get_num_params
 
-   pure module subroutine get_parameters(self, params)
+   impure module subroutine get_parameters(self, params)
       class(network), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
       integer :: n

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -379,7 +379,7 @@ contains
       end do
    end function get_num_params
 
-   impure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       class(network), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
       integer :: n

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -383,6 +383,18 @@ contains
     pure module subroutine set_parameters(self, params)
         class(network), intent(in) :: self
         real, intent(in) :: params(:)
+        integer :: n, consumed
+
+        ! check if the number of parameters is correct
+        if (size(params) .ne. self%get_num_params()) then
+            error stop 'network % set_parameters: number of parameters does not match'
+        end if
+
+        consumed = 0
+
+        do n = 1, size(self%layers)
+            consumed = consumed + self%layers(n)%set_parameters(params(consumed + 1:))
+        end do
     end subroutine set_parameters
 
     module subroutine train(self, input_data, output_data, batch_size, &

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -372,9 +372,6 @@ contains
       class(network), intent(in) :: self
       integer :: n, num_params
 
-      ! num_params = sum(self % layers % get_num_params())
-      ! get_num_params = self % layers % get_num_params()
-
       num_params = 0
 
       do n = 1, size(self % layers)

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -380,8 +380,8 @@ contains
         end do
     end subroutine get_parameters
 
-    pure module subroutine set_parameters(self, params)
-        class(network), intent(in) :: self
+    module subroutine set_parameters(self, params)
+        class(network), intent(in out) :: self
         real, intent(in) :: params(:)
         integer :: n, consumed
 

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -379,7 +379,7 @@ contains
       end do
    end function get_num_params
 
-   pure module subroutine get_parameters(self, params)
+   module subroutine get_parameters(self, params)
       class(network), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
       integer :: n

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -379,7 +379,7 @@ contains
       end do
    end function get_num_params
 
-   module subroutine get_parameters(self, params)
+   pure module subroutine get_parameters(self, params)
       class(network), intent(in) :: self
       real, allocatable, intent(inout) :: params(:)
       integer :: n

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -370,11 +370,16 @@ contains
 
    pure module function get_num_params(self) result(num_params)
       class(network), intent(in) :: self
-      integer :: num_params
+      integer :: n, num_params
 
-      num_params = sum(self % layers % get_num_params())
-
+      ! num_params = sum(self % layers % get_num_params())
       ! get_num_params = self % layers % get_num_params()
+
+      num_params = 0
+
+      do n = 1, size(self % layers)
+         num_params = num_params +  self % layers(n) % get_num_params()
+      end do
    end function get_num_params
 
    module subroutine train(self, input_data, output_data, batch_size, &

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -1,425 +1,431 @@
 submodule(nf_network) nf_network_submodule
 
-  use nf_conv2d_layer, only: conv2d_layer
-  use nf_dense_layer, only: dense_layer
-  use nf_flatten_layer, only: flatten_layer
-  use nf_input1d_layer, only: input1d_layer
-  use nf_input3d_layer, only: input3d_layer
-  use nf_maxpool2d_layer, only: maxpool2d_layer
-  use nf_reshape_layer, only: reshape3d_layer
-  use nf_io_hdf5, only: get_hdf5_dataset
-  use nf_keras, only: get_keras_h5_layers, keras_layer
-  use nf_layer, only: layer
-  use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
-  use nf_loss, only: quadratic_derivative
-  use nf_optimizers, only: sgd
-  use nf_parallel, only: tile_indices
+   use nf_conv2d_layer, only: conv2d_layer
+   use nf_dense_layer, only: dense_layer
+   use nf_flatten_layer, only: flatten_layer
+   use nf_input1d_layer, only: input1d_layer
+   use nf_input3d_layer, only: input3d_layer
+   use nf_maxpool2d_layer, only: maxpool2d_layer
+   use nf_reshape_layer, only: reshape3d_layer
+   use nf_io_hdf5, only: get_hdf5_dataset
+   use nf_keras, only: get_keras_h5_layers, keras_layer
+   use nf_layer, only: layer
+   use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
+   use nf_loss, only: quadratic_derivative
+   use nf_optimizers, only: sgd
+   use nf_parallel, only: tile_indices
 
-  implicit none
+   implicit none
 
 contains
 
-  module function network_from_layers(layers) result(res)
-    type(layer), intent(in) :: layers(:)
-    type(network) :: res
-    integer :: n
-
-    ! Error handling
-
-    ! There must be at least two layers
-    if (size(layers) < 2) &
-      error stop 'Error: A network must have at least 2 layers.'
-
-    ! The first layer must be an input layer
-    if (.not. layers(1) % name == 'input') &
-      error stop 'Error: First layer in the network must be an input layer.'
-
-    !TODO Ensure that the layers are in allowed sequence:
-    !TODO   input1d -> dense
-    !TODO   dense -> dense
-    !TODO   input3d -> conv2d, maxpool2d, flatten
-    !TODO   conv2d -> conv2d, maxpool2d, flatten
-    !TODO   maxpool2d -> conv2d, maxpool2d, flatten
-    !TODO   flatten -> dense
-    !TODO   reshape -> conv2d, maxpool2d
-
-    res % layers = layers
-
-    ! Loop over each layer in order and call the init methods.
-    ! This will allocate the data internal to each layer (e.g. weights, biases)
-    ! according to the size of the previous layer.
-    do n = 2, size(layers)
-      call res % layers(n) % init(res % layers(n - 1))
-    end do
-
-  end function network_from_layers
-
-
-  module function network_from_keras(filename) result(res)
-    character(*), intent(in) :: filename
-    type(network) :: res
-    type(keras_layer), allocatable :: keras_layers(:)
-    type(layer), allocatable :: layers(:)
-    character(:), allocatable :: layer_name
-    character(:), allocatable :: object_name
-    integer :: n
-
-    keras_layers = get_keras_h5_layers(filename)
-
-    allocate(layers(size(keras_layers)))
-
-    do n = 1, size(layers)
-
-      select case(keras_layers(n) % class)
-
-        case('Conv2D')
-
-          if (keras_layers(n) % kernel_size(1) &
-            /= keras_layers(n) % kernel_size(2)) &
-            error stop 'Non-square kernel in conv2d layer not supported.'
-
-          layers(n) = conv2d( &
-            keras_layers(n) % filters, &
-            !FIXME add support for non-square kernel
-            keras_layers(n) % kernel_size(1), &
-            keras_layers(n) % activation &
-          )
-
-        case('Dense')
-          layers(n) = dense( &
-            keras_layers(n) % units(1), &
-            keras_layers(n) % activation &
-          )
-
-        case('Flatten')
-          layers(n) = flatten()
-
-        case('InputLayer')
-          if (size(keras_layers(n) % units) == 1) then
-            ! input1d
-            layers(n) = input(keras_layers(n) % units(1))
-          else
-            ! input3d
-            layers(n) = input(keras_layers(n) % units)
-          end if
-
-        case('MaxPooling2D')
-
-          if (keras_layers(n) % pool_size(1) &
-            /= keras_layers(n) % pool_size(2)) &
-            error stop 'Non-square pool in maxpool2d layer not supported.'
-
-          if (keras_layers(n) % strides(1) &
-            /= keras_layers(n) % strides(2)) &
-            error stop 'Unequal strides in maxpool2d layer are not supported.'
-
-          layers(n) = maxpool2d( &
-            !FIXME add support for non-square pool and stride
-            keras_layers(n) % pool_size(1), &
-            keras_layers(n) % strides(1) &
-          )
-
-        case('Reshape')
-          layers(n) = reshape(keras_layers(n) % target_shape)
-
-        case default
-          error stop 'This Keras layer is not supported'
-
-      end select
-
-    end do
-
-    res = network(layers)
-
-    ! Loop over layers and read weights and biases from the Keras h5 file
-    ! for each; currently only dense layers are implemented.
-    do n = 2, size(res % layers)
-
-      layer_name = keras_layers(n) % name
-
-      select type(this_layer => res % layers(n) % p)
-
-        type is(conv2d_layer)
-          ! Read biases from file
-          object_name = '/model_weights/' // layer_name // '/' &
-            // layer_name // '/bias:0'
-          call get_hdf5_dataset(filename, object_name, this_layer % biases)
-
-          ! Read weights from file
-          object_name = '/model_weights/' // layer_name // '/' &
-            // layer_name // '/kernel:0'
-          call get_hdf5_dataset(filename, object_name, this_layer % kernel)
-
-        type is(dense_layer)
-
-          ! Read biases from file
-          object_name = '/model_weights/' // layer_name // '/' &
-            // layer_name // '/bias:0'
-          call get_hdf5_dataset(filename, object_name, this_layer % biases)
-
-          ! Read weights from file
-          object_name = '/model_weights/' // layer_name // '/' &
-            // layer_name // '/kernel:0'
-          call get_hdf5_dataset(filename, object_name, this_layer % weights)
-
-        type is(flatten_layer)
-          ! Nothing to do
-          continue
-
-        type is(maxpool2d_layer)
-          ! Nothing to do
-          continue
-
-        type is(reshape3d_layer)
-          ! Nothing to do
-          continue
-
-        class default
-          error stop 'Internal error in network_from_keras(); ' &
-            // 'mismatch in layer types between the Keras and ' &
-            // 'neural-fortran model layers.'
-
-      end select
-
-  end do
-
-  end function network_from_keras
-
-
-  pure module subroutine backward(self, output)
-    class(network), intent(in out) :: self
-    real, intent(in) :: output(:)
-    real, allocatable :: gradient(:)
-    integer :: n, num_layers
-
-    num_layers = size(self % layers)
-
-    ! Iterate backward over layers, from the output layer
-    ! to the first non-input layer
-    do n = num_layers, 2, -1
-
-      if (n == num_layers) then
-        ! Output layer; apply the loss function
-        select type(this_layer => self % layers(n) % p)
-          type is(dense_layer)
-            gradient = quadratic_derivative(output, this_layer % output)
-        end select
-      else
-        ! Hidden layer; take the gradient from the next layer
-        select type(next_layer => self % layers(n + 1) % p)
-          type is(dense_layer)
-            gradient = next_layer % gradient
-        end select
-      end if
-
-      call self % layers(n) % backward(self % layers(n - 1), gradient)
-
-    end do
-
-  end subroutine backward
-
-
-  pure module subroutine forward_1d(self, input)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:)
-    integer :: n
-
-    ! Set the input array into the input layer
-    select type(input_layer => self % layers(1) % p); type is(input1d_layer)
-      call input_layer % set(input)
-    end select
-
-    do n = 2, size(self % layers)
-      call self % layers(n) % forward(self % layers(n - 1))
-    end do
-
-  end subroutine forward_1d
-
-
-  pure module subroutine forward_3d(self, input)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    integer :: n
-
-    ! Set the input array into the input layer
-    select type(input_layer => self % layers(1) % p); type is(input3d_layer)
-      call input_layer % set(input)
-    end select
-
-    do n = 2, size(self % layers)
-      call self % layers(n) % forward(self % layers(n - 1))
-    end do
-
-  end subroutine forward_3d
-
-
-  module function predict_1d(self, input) result(res)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:)
-    real, allocatable :: res(:)
-    integer :: num_layers
-
-    num_layers = size(self % layers)
-
-    call self % forward(input)
-
-    select type(output_layer => self % layers(num_layers) % p)
-      type is(dense_layer)
-        res = output_layer % output
-      type is(flatten_layer)
-        res = output_layer % output
-      class default
-        error stop 'network % output not implemented for this output layer'
-    end select
-
-  end function predict_1d
-
-
-  module function predict_3d(self, input) result(res)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    real, allocatable :: res(:)
-    integer :: num_layers
-
-    num_layers = size(self % layers)
-
-    call self % forward(input)
-
-    select type(output_layer => self % layers(num_layers) % p)
-      type is(conv2d_layer)
-        !FIXME flatten the result for now; find a better solution
-        res = pack(output_layer % output, .true.)
-      type is(dense_layer)
-        res = output_layer % output
-      type is(flatten_layer)
-        res = output_layer % output
-      class default
-        error stop 'network % output not implemented for this output layer'
-    end select
-
-  end function predict_3d
-
-
-  module function predict_batch_1d(self, input) result(res)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:,:)
-    real, allocatable :: res(:,:)
-    integer :: i, batch_size, num_layers, output_size
-
-    num_layers = size(self % layers)
-    batch_size = size(input, dim=rank(input))
-    output_size = product(self % layers(num_layers) % layer_shape)
-
-    allocate(res(output_size, batch_size))
-
-    batch: do concurrent(i = 1:size(res, dim=2))
-
-      call self % forward(input(:,i))
-
-      select type(output_layer => self % layers(num_layers) % p)
-        type is(dense_layer)
-          res(:,i) = output_layer % output
-        type is(flatten_layer)
-          res(:,i) = output_layer % output
-        class default
-          error stop 'network % output not implemented for this output layer'
-      end select
-
-    end do batch
-
-  end function predict_batch_1d
-
-
-  module function predict_batch_3d(self, input) result(res)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input(:,:,:,:)
-    real, allocatable :: res(:,:)
-    integer :: i, batch_size, num_layers, output_size
-
-    num_layers = size(self % layers)
-    batch_size = size(input, dim=rank(input))
-    output_size = product(self % layers(num_layers) % layer_shape)
-
-    allocate(res(output_size, batch_size))
-
-    batch: do concurrent(i = 1:batch_size)
-
-      call self % forward(input(:,:,:,i))
-
-      select type(output_layer => self % layers(num_layers) % p)
-        type is(conv2d_layer)
-          !FIXME flatten the result for now; find a better solution
-          res(:,i) = pack(output_layer % output, .true.)
-        type is(dense_layer)
-          res(:,i) = output_layer % output
-        type is(flatten_layer)
-          res(:,i) = output_layer % output
-        class default
-          error stop 'network % output not implemented for this output layer'
-      end select
-
-    end do batch
-
-  end function predict_batch_3d
-
-
-  module subroutine print_info(self)
-    class(network), intent(in) :: self
-    call self % layers % print_info()
-  end subroutine print_info
-
-
-  module subroutine train(self, input_data, output_data, batch_size, &
-                          epochs, optimizer)
-    class(network), intent(in out) :: self
-    real, intent(in) :: input_data(:,:)
-    real, intent(in) :: output_data(:,:)
-    integer, intent(in) :: batch_size
-    integer, intent(in) :: epochs
-    type(sgd), intent(in) :: optimizer
-
-    real :: pos
-    integer :: dataset_size
-    integer :: batch_start, batch_end
-    integer :: i, j, n
-    integer :: istart, iend, indices(2)
-
-    dataset_size = size(output_data, dim=2)
-
-    epoch_loop: do n = 1, epochs
-      batch_loop: do i = 1, dataset_size / batch_size
-
-      ! Pull a random mini-batch from the dataset
-      call random_number(pos)
-      batch_start = int(pos * (dataset_size - batch_size + 1)) + 1
-      batch_end = batch_start + batch_size - 1
-
-      ! FIXME shuffle in a way that doesn't require co_broadcast
-      call co_broadcast(batch_start, 1)
-      call co_broadcast(batch_end, 1)
-
-      ! Distribute the batch in nearly equal pieces to all images
-      indices = tile_indices(batch_size)
-      istart = indices(1) + batch_start - 1
-      iend = indices(2) + batch_start - 1
-
-      do concurrent(j = istart:iend)
-        call self % forward(input_data(:,j))
-        call self % backward(output_data(:,j))
+   module function network_from_layers(layers) result(res)
+      type(layer), intent(in) :: layers(:)
+      type(network) :: res
+      integer :: n
+
+      ! Error handling
+
+      ! There must be at least two layers
+      if (size(layers) < 2) &
+         error stop 'Error: A network must have at least 2 layers.'
+
+      ! The first layer must be an input layer
+      if (.not. layers(1) % name == 'input') &
+         error stop 'Error: First layer in the network must be an input layer.'
+
+      !TODO Ensure that the layers are in allowed sequence:
+      !TODO   input1d -> dense
+      !TODO   dense -> dense
+      !TODO   input3d -> conv2d, maxpool2d, flatten
+      !TODO   conv2d -> conv2d, maxpool2d, flatten
+      !TODO   maxpool2d -> conv2d, maxpool2d, flatten
+      !TODO   flatten -> dense
+      !TODO   reshape -> conv2d, maxpool2d
+
+      res % layers = layers
+
+      ! Loop over each layer in order and call the init methods.
+      ! This will allocate the data internal to each layer (e.g. weights, biases)
+      ! according to the size of the previous layer.
+      do n = 2, size(layers)
+         call res % layers(n) % init(res % layers(n - 1))
       end do
 
-      call self % update(optimizer % learning_rate / batch_size)
+   end function network_from_layers
+
+
+   module function network_from_keras(filename) result(res)
+      character(*), intent(in) :: filename
+      type(network) :: res
+      type(keras_layer), allocatable :: keras_layers(:)
+      type(layer), allocatable :: layers(:)
+      character(:), allocatable :: layer_name
+      character(:), allocatable :: object_name
+      integer :: n
+
+      keras_layers = get_keras_h5_layers(filename)
+
+      allocate(layers(size(keras_layers)))
+
+      do n = 1, size(layers)
+
+         select case(keras_layers(n) % class)
+
+          case('Conv2D')
+
+            if (keras_layers(n) % kernel_size(1) &
+               /= keras_layers(n) % kernel_size(2)) &
+               error stop 'Non-square kernel in conv2d layer not supported.'
+
+            layers(n) = conv2d( &
+               keras_layers(n) % filters, &
+            !FIXME add support for non-square kernel
+               keras_layers(n) % kernel_size(1), &
+               keras_layers(n) % activation &
+               )
+
+          case('Dense')
+            layers(n) = dense( &
+               keras_layers(n) % units(1), &
+               keras_layers(n) % activation &
+               )
+
+          case('Flatten')
+            layers(n) = flatten()
+
+          case('InputLayer')
+            if (size(keras_layers(n) % units) == 1) then
+               ! input1d
+               layers(n) = input(keras_layers(n) % units(1))
+            else
+               ! input3d
+               layers(n) = input(keras_layers(n) % units)
+            end if
+
+          case('MaxPooling2D')
+
+            if (keras_layers(n) % pool_size(1) &
+               /= keras_layers(n) % pool_size(2)) &
+               error stop 'Non-square pool in maxpool2d layer not supported.'
+
+            if (keras_layers(n) % strides(1) &
+               /= keras_layers(n) % strides(2)) &
+               error stop 'Unequal strides in maxpool2d layer are not supported.'
+
+            layers(n) = maxpool2d( &
+            !FIXME add support for non-square pool and stride
+               keras_layers(n) % pool_size(1), &
+               keras_layers(n) % strides(1) &
+               )
+
+          case('Reshape')
+            layers(n) = reshape(keras_layers(n) % target_shape)
+
+          case default
+            error stop 'This Keras layer is not supported'
+
+         end select
+
+      end do
+
+      res = network(layers)
+
+      ! Loop over layers and read weights and biases from the Keras h5 file
+      ! for each; currently only dense layers are implemented.
+      do n = 2, size(res % layers)
+
+         layer_name = keras_layers(n) % name
+
+         select type(this_layer => res % layers(n) % p)
+
+          type is(conv2d_layer)
+            ! Read biases from file
+            object_name = '/model_weights/' // layer_name // '/' &
+               // layer_name // '/bias:0'
+            call get_hdf5_dataset(filename, object_name, this_layer % biases)
+
+            ! Read weights from file
+            object_name = '/model_weights/' // layer_name // '/' &
+               // layer_name // '/kernel:0'
+            call get_hdf5_dataset(filename, object_name, this_layer % kernel)
+
+          type is(dense_layer)
+
+            ! Read biases from file
+            object_name = '/model_weights/' // layer_name // '/' &
+               // layer_name // '/bias:0'
+            call get_hdf5_dataset(filename, object_name, this_layer % biases)
+
+            ! Read weights from file
+            object_name = '/model_weights/' // layer_name // '/' &
+               // layer_name // '/kernel:0'
+            call get_hdf5_dataset(filename, object_name, this_layer % weights)
+
+          type is(flatten_layer)
+            ! Nothing to do
+            continue
+
+          type is(maxpool2d_layer)
+            ! Nothing to do
+            continue
+
+          type is(reshape3d_layer)
+            ! Nothing to do
+            continue
+
+          class default
+            error stop 'Internal error in network_from_keras(); ' &
+               // 'mismatch in layer types between the Keras and ' &
+               // 'neural-fortran model layers.'
+
+         end select
+
+      end do
+
+   end function network_from_keras
+
+
+   pure module subroutine backward(self, output)
+      class(network), intent(in out) :: self
+      real, intent(in) :: output(:)
+      real, allocatable :: gradient(:)
+      integer :: n, num_layers
+
+      num_layers = size(self % layers)
+
+      ! Iterate backward over layers, from the output layer
+      ! to the first non-input layer
+      do n = num_layers, 2, -1
+
+         if (n == num_layers) then
+            ! Output layer; apply the loss function
+            select type(this_layer => self % layers(n) % p)
+             type is(dense_layer)
+               gradient = quadratic_derivative(output, this_layer % output)
+            end select
+         else
+            ! Hidden layer; take the gradient from the next layer
+            select type(next_layer => self % layers(n + 1) % p)
+             type is(dense_layer)
+               gradient = next_layer % gradient
+            end select
+         end if
+
+         call self % layers(n) % backward(self % layers(n - 1), gradient)
+
+      end do
+
+   end subroutine backward
+
+
+   pure module subroutine forward_1d(self, input)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:)
+      integer :: n
+
+      ! Set the input array into the input layer
+      select type(input_layer => self % layers(1) % p); type is(input1d_layer)
+         call input_layer % set(input)
+      end select
+
+      do n = 2, size(self % layers)
+         call self % layers(n) % forward(self % layers(n - 1))
+      end do
+
+   end subroutine forward_1d
+
+
+   pure module subroutine forward_3d(self, input)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:,:,:)
+      integer :: n
+
+      ! Set the input array into the input layer
+      select type(input_layer => self % layers(1) % p); type is(input3d_layer)
+         call input_layer % set(input)
+      end select
+
+      do n = 2, size(self % layers)
+         call self % layers(n) % forward(self % layers(n - 1))
+      end do
+
+   end subroutine forward_3d
+
+
+   module function predict_1d(self, input) result(res)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:)
+      real, allocatable :: res(:)
+      integer :: num_layers
+
+      num_layers = size(self % layers)
+
+      call self % forward(input)
+
+      select type(output_layer => self % layers(num_layers) % p)
+       type is(dense_layer)
+         res = output_layer % output
+       type is(flatten_layer)
+         res = output_layer % output
+       class default
+         error stop 'network % output not implemented for this output layer'
+      end select
+
+   end function predict_1d
+
+
+   module function predict_3d(self, input) result(res)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:,:,:)
+      real, allocatable :: res(:)
+      integer :: num_layers
+
+      num_layers = size(self % layers)
+
+      call self % forward(input)
+
+      select type(output_layer => self % layers(num_layers) % p)
+       type is(conv2d_layer)
+         !FIXME flatten the result for now; find a better solution
+         res = pack(output_layer % output, .true.)
+       type is(dense_layer)
+         res = output_layer % output
+       type is(flatten_layer)
+         res = output_layer % output
+       class default
+         error stop 'network % output not implemented for this output layer'
+      end select
+
+   end function predict_3d
+
+
+   module function predict_batch_1d(self, input) result(res)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:,:)
+      real, allocatable :: res(:,:)
+      integer :: i, batch_size, num_layers, output_size
+
+      num_layers = size(self % layers)
+      batch_size = size(input, dim=rank(input))
+      output_size = product(self % layers(num_layers) % layer_shape)
+
+      allocate(res(output_size, batch_size))
+
+      batch: do concurrent(i = 1:size(res, dim=2))
+
+         call self % forward(input(:,i))
+
+         select type(output_layer => self % layers(num_layers) % p)
+          type is(dense_layer)
+            res(:,i) = output_layer % output
+          type is(flatten_layer)
+            res(:,i) = output_layer % output
+          class default
+            error stop 'network % output not implemented for this output layer'
+         end select
+
+      end do batch
+
+   end function predict_batch_1d
+
+
+   module function predict_batch_3d(self, input) result(res)
+      class(network), intent(in out) :: self
+      real, intent(in) :: input(:,:,:,:)
+      real, allocatable :: res(:,:)
+      integer :: i, batch_size, num_layers, output_size
+
+      num_layers = size(self % layers)
+      batch_size = size(input, dim=rank(input))
+      output_size = product(self % layers(num_layers) % layer_shape)
+
+      allocate(res(output_size, batch_size))
+
+      batch: do concurrent(i = 1:batch_size)
+
+         call self % forward(input(:,:,:,i))
+
+         select type(output_layer => self % layers(num_layers) % p)
+          type is(conv2d_layer)
+            !FIXME flatten the result for now; find a better solution
+            res(:,i) = pack(output_layer % output, .true.)
+          type is(dense_layer)
+            res(:,i) = output_layer % output
+          type is(flatten_layer)
+            res(:,i) = output_layer % output
+          class default
+            error stop 'network % output not implemented for this output layer'
+         end select
+
+      end do batch
+
+   end function predict_batch_3d
+
+
+   module subroutine print_info(self)
+      class(network), intent(in) :: self
+      call self % layers % print_info()
+   end subroutine print_info
+
+   module integer function get_num_params(self)
+   class(network), intent(in) :: self
+   !call self % layers % print_info()
+   ! get_num_params = self % layers % get_num_params()
+   get_num_params = 0
+end function get_num_params
+
+module subroutine train(self, input_data, output_data, batch_size, &
+   epochs, optimizer)
+   class(network), intent(in out) :: self
+   real, intent(in) :: input_data(:,:)
+   real, intent(in) :: output_data(:,:)
+   integer, intent(in) :: batch_size
+   integer, intent(in) :: epochs
+   type(sgd), intent(in) :: optimizer
+
+   real :: pos
+   integer :: dataset_size
+   integer :: batch_start, batch_end
+   integer :: i, j, n
+   integer :: istart, iend, indices(2)
+
+   dataset_size = size(output_data, dim=2)
+
+   epoch_loop: do n = 1, epochs
+      batch_loop: do i = 1, dataset_size / batch_size
+
+         ! Pull a random mini-batch from the dataset
+         call random_number(pos)
+         batch_start = int(pos * (dataset_size - batch_size + 1)) + 1
+         batch_end = batch_start + batch_size - 1
+
+         ! FIXME shuffle in a way that doesn't require co_broadcast
+         call co_broadcast(batch_start, 1)
+         call co_broadcast(batch_end, 1)
+
+         ! Distribute the batch in nearly equal pieces to all images
+         indices = tile_indices(batch_size)
+         istart = indices(1) + batch_start - 1
+         iend = indices(2) + batch_start - 1
+
+         do concurrent(j = istart:iend)
+            call self % forward(input_data(:,j))
+            call self % backward(output_data(:,j))
+         end do
+
+         call self % update(optimizer % learning_rate / batch_size)
 
       end do batch_loop
-    end do epoch_loop
+   end do epoch_loop
 
-  end subroutine train
+end subroutine train
 
 
-  module subroutine update(self, learning_rate)
-    class(network), intent(in out) :: self
-    real, intent(in) :: learning_rate
-    call self % layers % update(learning_rate)
-  end subroutine update
+module subroutine update(self, learning_rate)
+   class(network), intent(in out) :: self
+   real, intent(in) :: learning_rate
+   call self % layers % update(learning_rate)
+end subroutine update
 
 end submodule nf_network_submodule


### PR DESCRIPTION
This is a combined pull request. I don't know how to make a separate PR for the CMakeList.txt only.

* the example folder contains an extra program ```params.f90``` (itself a slightly modified ```sine.f90``` with ```get_num_params()``` called at the end)
* added the ```get_num_params()``` pure function across the source code.

You'd better check ```get_num_params(self) result(num_params)``` in the nf_layer_submodule.f90. The actual non-zero number of parameters are only returned from the dense and conv2d layers. Hopefully this is correct.

Love it or hate it, the GitHub CoPilot made very useful initial suggestions whilst adding this code. Hopefully the new code follows your style (thank you copilot!).