### PR TITLE
Introduce optimizer_base_type in support of different optimizers

### DIFF
--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -3,7 +3,7 @@ module nf_network
   !! This module provides the network type to create new models.
 
   use nf_layer, only: layer
-  use nf_optimizers, only: sgd
+  use nf_optimizers, only: optimizer_base_type
 
   implicit none
 
@@ -193,7 +193,7 @@ module nf_network
         !! Set to `size(input_data, dim=2)` for a batch gradient descent.
       integer, intent(in) :: epochs
         !! Number of epochs to run
-      type(sgd), intent(in) :: optimizer
+      class(optimizer_base_type), intent(in) :: optimizer
         !! Optimizer instance; currently this is an `sgd` optimizer type
         !! and it will be made to be a more general optimizer type.
     end subroutine train

--- a/src/nf/nf_optimizers.f90
+++ b/src/nf/nf_optimizers.f90
@@ -5,9 +5,13 @@ module nf_optimizers
   implicit none
 
   private
-  public :: sgd
+  public :: optimizer_base_type, sgd
 
-  type :: sgd
+  type, abstract :: optimizer_base_type
+    character(:), allocatable :: name
+  end type optimizer_base_type
+
+  type, extends(optimizer_base_type) :: sgd
     !! Stochastic Gradient Descent optimizer
     real :: learning_rate
     real :: momentum = 0 !TODO


### PR DESCRIPTION
This is the first step toward decoupling the optimizer logic from the concrete layers.

This PR only introduces the abstract `optimizer_base_type` and a concrete `sgd` type. 

The update of weights is still hardcoded in `network % train` and the concrete layer implementations; decoupling that remains a TODO.

In a nutshell, the idea is to have

* Concrete optimizer types such as `sgd`, `adam`, etc. in `nf_optimizers.f90` (and its submodules, eventually);
* The type constructors would expect optimizer parameters from the user (e.g. `adam(learning_rate, beta1, beta2, epsilon, ...)`)
* Each concrete type would define an `update` subroutine which would expect the needed gradients (`dw`, `db`) as input, and also the weights and biases arrays as `intent(out)` to update.

@rweed let me know if this approach seems reasonable to you. 