### PR TITLE
Insert a flatten layer if a dense layer follows a layer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2022 neural-fortran contributors
+Copyright (c) 2018-2023 neural-fortran contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/cnn_mnist.f90
+++ b/example/cnn_mnist.f90
@@ -28,7 +28,6 @@ program cnn_mnist
     maxpool2d(pool_size=2), &
     conv2d(filters=16, kernel_size=3, activation='relu'), &
     maxpool2d(pool_size=2), &
-    flatten(), &
     dense(10, activation='softmax') &
   ])
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,9 +1,9 @@
 name = "neural-fortran"
-version = "0.10.0"
+version = "0.11.0"
 license = "MIT"
 author = "Milan Curcic"
 maintainer = "milancurcic@hey.com"
-copyright = "Copyright 2018-2022, neural-fortran contributors"
+copyright = "Copyright 2018-2023, neural-fortran contributors"
 
 [build]
 external-modules = "hdf5"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(execid
   conv2d_layer
   maxpool2d_layer
   flatten_layer
+  insert_flatten
   reshape_layer
   dense_network
   get_set_network_params

--- a/test/test_insert_flatten.f90
+++ b/test/test_insert_flatten.f90
@@ -1,0 +1,64 @@
+program test_insert_flatten
+
+  use iso_fortran_env, only: stderr => error_unit
+  use nf, only: network, input, conv2d, maxpool2d, flatten, dense, reshape
+
+  implicit none
+
+  type(network) :: net
+  logical :: ok = .true.
+
+  net = network([ &
+    input([3, 32, 32]), &
+    dense(10) &
+  ])
+
+  if (.not. net % layers(2) % name == 'flatten') then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer inserted after input3d.. failed'
+  end if
+
+  net = network([ &
+    input([3, 32, 32]), &
+    conv2d(filters=1, kernel_size=3), &
+    dense(10) &
+  ])
+
+  !call net % print_info()
+
+  if (.not. net % layers(3) % name == 'flatten') then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer inserted after conv2d.. failed'
+  end if
+
+  net = network([ &
+    input([3, 32, 32]), &
+    conv2d(filters=1, kernel_size=3), &
+    maxpool2d(pool_size=2, stride=2), &
+    dense(10) &
+  ])
+
+  if (.not. net % layers(4) % name == 'flatten') then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer inserted after maxpool2d.. failed'
+  end if
+
+  net = network([ &
+    input(4), &
+    reshape([1, 2, 2]), &
+    dense(4) &
+  ])
+
+  if (.not. net % layers(3) % name == 'flatten') then
+    ok = .false.
+    write(stderr, '(a)') 'flatten layer inserted after reshape.. failed'
+  end if
+
+  if (ok) then
+    print '(a)', 'test_insert_flatten: All tests passed.'
+  else
+    write(stderr, '(a)') 'test_insert_flatten: One or more tests failed.'
+    stop 1
+  end if
+
+end program test_insert_flatten


### PR DESCRIPTION
With this PR it's no longer necessary to explicitly flatten the output from a layer with 3-d output for input to `dense` layers. It `flatten()` is omitted in the network constructor, the constructor will take care of it.