### PR TITLE
WIP: Update CMake to allow for prebuild dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(FetchContent)
 include(cmake/options.cmake)
 include(cmake/compilers.cmake)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(cmake/functional.cmake)
 include(cmake/h5fortran.cmake)
 include(cmake/json.cmake)

--- a/cmake/Findfunctional.cmake
+++ b/cmake/Findfunctional.cmake
@@ -8,15 +8,12 @@ include(FindPackageHandleStandardArgs)
 
 find_library(functional_LIBRARY
   NAMES functional)
-message(STATUS "functional_LIBRARY: ${functional_LIBRARY}")
 
 find_path(functional_INCLUDE_DIR
   NAMES functional.mod)
-message(STATUS "functional_INCLUDE_DIR: ${functional_INCLUDE_DIR}")
 
 find_package_handle_standard_args(functional DEFAULT_MSG
   functional_LIBRARY functional_INCLUDE_DIR)
-message(STATUS "functional_FOUND: ${functional_FOUND}")
 
 if (functional_FOUND)
   mark_as_advanced(functional_INCLUDE_DIR)

--- a/cmake/Findfunctional.cmake
+++ b/cmake/Findfunctional.cmake
@@ -1,0 +1,30 @@
+# This is a CMake file to detect the installation of the functional-fortran library
+# An install of this library provides:
+#
+# 1. A library named "libfunctional.a"
+# 2. A variety of Fortran .mod files
+
+include(FindPackageHandleStandardArgs)
+
+find_library(functional_LIBRARY
+  NAMES functional)
+message(STATUS "functional_LIBRARY: ${functional_LIBRARY}")
+
+find_path(functional_INCLUDE_DIR
+  NAMES functional.mod)
+message(STATUS "functional_INCLUDE_DIR: ${functional_INCLUDE_DIR}")
+
+find_package_handle_standard_args(functional DEFAULT_MSG
+  functional_LIBRARY functional_INCLUDE_DIR)
+message(STATUS "functional_FOUND: ${functional_FOUND}")
+
+if (functional_FOUND)
+  mark_as_advanced(functional_INCLUDE_DIR)
+  mark_as_advanced(functional_LIBRARY)
+endif()
+
+if (functional_FOUND AND NOT functional::functional)
+  add_library(functional::functional IMPORTED STATIC)
+  set_property(TARGET functional::functional PROPERTY IMPORTED_LOCATION ${functional_LIBRARY})
+  target_include_directories(functional::functional INTERFACE ${functional_INCLUDE_DIR})
+endif()

--- a/cmake/functional.cmake
+++ b/cmake/functional.cmake
@@ -1,18 +1,26 @@
-FetchContent_Declare(functional
-  GIT_REPOSITORY https://github.com/wavebitscientific/functional-fortran
-  GIT_TAG 0.6.1
-  GIT_SHALLOW true
-)
+find_package(functional QUIET)
 
-FetchContent_Populate(functional)
+if (NOT functional_FOUND)
+  message(STATUS "functional not found, fetching from GitHub")
 
-add_library(functional ${functional_SOURCE_DIR}/src/functional.f90)
-target_include_directories(functional PUBLIC
-$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-$<INSTALL_INTERFACE:include>
-)
+  FetchContent_Declare(functional
+    GIT_REPOSITORY https://github.com/wavebitscientific/functional-fortran
+    GIT_TAG 0.6.1
+    GIT_SHALLOW true
+  )
 
-add_library(functional::functional INTERFACE IMPORTED GLOBAL)
-target_link_libraries(functional::functional INTERFACE functional)
+  FetchContent_Populate(functional)
 
-install(TARGETS functional)
+  add_library(functional ${functional_SOURCE_DIR}/src/functional.f90)
+  target_include_directories(functional PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+  add_library(functional::functional INTERFACE IMPORTED GLOBAL)
+  target_link_libraries(functional::functional INTERFACE functional)
+
+  install(TARGETS functional)
+else ()
+  message(STATUS "functional found, using system version")
+endif ()

--- a/cmake/h5fortran.cmake
+++ b/cmake/h5fortran.cmake
@@ -6,6 +6,7 @@ if (HDF5_HL_FOUND)
 endif()
 if (HDF5_IS_PARALLEL)
   message(STATUS "HDF5 is parallel")
+  find_package(MPI REQUIRED COMPONENTS Fortran)
   target_link_libraries(HDF5::HDF5 INTERFACE MPI::MPI_Fortran)
 endif()
 

--- a/cmake/h5fortran.cmake
+++ b/cmake/h5fortran.cmake
@@ -1,15 +1,33 @@
-set(h5fortran_BUILD_TESTING false)
+find_package(HDF5 COMPONENTS Fortran REQUIRED
+  OPTIONAL_COMPONENTS C HL)
+if (HDF5_HL_FOUND)
+  message(STATUS "HDF5 HL is available")
+  target_link_libraries(HDF5::HDF5 INTERFACE hdf5::hdf5_hl hdf5::hdf5_hl_fortran)
+endif()
+if (HDF5_IS_PARALLEL)
+  message(STATUS "HDF5 is parallel")
+  target_link_libraries(HDF5::HDF5 INTERFACE MPI::MPI_Fortran)
+endif()
 
-FetchContent_Declare(h5fortran
-  GIT_REPOSITORY https://github.com/geospace-code/h5fortran
-  GIT_TAG v4.6.3
-  GIT_SHALLOW true
-)
+find_package(h5fortran 4.6.3 QUIET)
 
-FetchContent_MakeAvailable(h5fortran)
+if (NOT h5fortran_FOUND)
+  message(STATUS "h5fortran not found, fetching from GitHub")
 
-file(MAKE_DIRECTORY ${h5fortran_BINARY_DIR}/include)
+  set(h5fortran_BUILD_TESTING false)
+
+  FetchContent_Declare(h5fortran
+    GIT_REPOSITORY https://github.com/geospace-code/h5fortran
+    GIT_TAG v4.6.3
+    GIT_SHALLOW true
+  )
+
+  FetchContent_MakeAvailable(h5fortran)
+
+  file(MAKE_DIRECTORY ${h5fortran_BINARY_DIR}/include)
 
 
-list(APPEND CMAKE_MODULE_PATH ${h5fortran_SOURCE_DIR}/cmake/Modules)
-find_package(HDF5 COMPONENTS Fortran REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH ${h5fortran_SOURCE_DIR}/cmake/Modules)
+else()
+  message(STATUS "h5fortran found: ${h5fortran_DIR}")
+endif()

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -1,35 +1,51 @@
-# use our own CMake script to build jsonfortran instead of jsonfortran/CMakelists.txt
+# Per the jsonfortran README, if you build with their CMakeLists.txt, you will
+# make a jsonfortran-${CMAKE_Fortran_COMPILER_ID} package, so you have to find_package
+# on that.
+find_package(jsonfortran-${CMAKE_Fortran_COMPILER_ID} 8.3.0 QUIET)
 
-FetchContent_Declare(jsonfortran
-  GIT_REPOSITORY https://github.com/jacobwilliams/json-fortran
-  GIT_TAG 8.3.0
-  GIT_SHALLOW true
-)
+if (NOT jsonfortran-${CMAKE_Fortran_COMPILER_ID}_FOUND)
+  message(STATUS "jsonfortran not found, fetching from github")
 
-FetchContent_Populate(jsonfortran)
+  # use our own CMake script to build jsonfortran instead of jsonfortran/CMakelists.txt
 
-SET(JSON_REAL_KIND "REAL64")
-SET(JSON_INT_KIND "INT32")
+  FetchContent_Declare(jsonfortran
+    GIT_REPOSITORY https://github.com/jacobwilliams/json-fortran
+    GIT_TAG 8.3.0
+    GIT_SHALLOW true
+  )
 
-set(_src ${jsonfortran_SOURCE_DIR}/src)
+  FetchContent_Populate(jsonfortran)
 
-set (JF_LIB_SRCS
-${_src}/json_kinds.F90
-${_src}/json_parameters.F90
-${_src}/json_string_utilities.F90
-${_src}/json_value_module.F90
-${_src}/json_file_module.F90
-${_src}/json_module.F90
-)
+  SET(JSON_REAL_KIND "REAL64")
+  SET(JSON_INT_KIND "INT32")
 
-add_library(jsonfortran ${JF_LIB_SRCS})
-target_compile_definitions(jsonfortran PRIVATE ${JSON_REAL_KIND} ${JSON_INT_KIND})
-target_include_directories(jsonfortran PUBLIC
-$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
-$<INSTALL_INTERFACE:include>
-)
+  set(_src ${jsonfortran_SOURCE_DIR}/src)
 
-add_library(jsonfortran::jsonfortran INTERFACE IMPORTED GLOBAL)
-target_link_libraries(jsonfortran::jsonfortran INTERFACE jsonfortran)
+  set (JF_LIB_SRCS
+  ${_src}/json_kinds.F90
+  ${_src}/json_parameters.F90
+  ${_src}/json_string_utilities.F90
+  ${_src}/json_value_module.F90
+  ${_src}/json_file_module.F90
+  ${_src}/json_module.F90
+  )
 
-install(TARGETS jsonfortran)
+  add_library(jsonfortran ${JF_LIB_SRCS})
+  target_compile_definitions(jsonfortran PRIVATE ${JSON_REAL_KIND} ${JSON_INT_KIND})
+  target_include_directories(jsonfortran PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  )
+
+  add_library(jsonfortran::jsonfortran INTERFACE IMPORTED GLOBAL)
+  target_link_libraries(jsonfortran::jsonfortran INTERFACE jsonfortran)
+
+  install(TARGETS jsonfortran)
+else ()
+  message(STATUS "jsonfortran found: ${jsonfortran-${CMAKE_Fortran_COMPILER_ID}_DIR}")
+  # We need to make a jsonfortran::jsonfortran target for the jsonfortran we found because
+  # neural-fortran is expecting it. It looks like it is a lower-case version of the compiler
+  # name, so we'll just do that.
+  string(TOLOWER ${CMAKE_Fortran_COMPILER_ID} lower_compiler_id)
+  add_library(jsonfortran::jsonfortran ALIAS jsonfortran-${lower_compiler_id}::jsonfortran)
+endif ()


### PR DESCRIPTION
# WORK IN PROGRESS

This is a work in progress. It works for me but I've currently broken the regular build. Nuts.

---

Closes #128 

This PR is to allow prebuilt functional-fortran, h5fortran, and json-fortran to be used with neural-fortran.