### PR TITLE
Example program that shows how to access internal layer parameters

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,6 +4,7 @@ foreach(execid
   dense_mnist
   dense_from_keras
   get_set_network_params
+  network_parameters
   simple
   sine
   quadratic

--- a/example/network_parameters.f90
+++ b/example/network_parameters.f90
@@ -1,0 +1,33 @@
+program network_parameters
+  ! This program demonstrates how to access network parameters (weights and
+  ! biases) from the layers' internal data structures.
+  use nf, only: dense, input, layer, network
+  use nf_conv2d_layer, only: conv2d_layer
+  use nf_dense_layer, only: dense_layer
+
+  implicit none
+
+  type(network) :: net
+  integer :: n
+
+  net = network([input(3), dense(5), dense(2)])
+
+  do n = 1, size(net % layers)
+    print *, "Layer ", n, "is " // net % layers(n) % name
+    select type (this_layer => net % layers(n) % p)
+      type is (dense_layer) 
+        print *, "  with weights of shape", shape(this_layer % weights)
+        print *, "  and ", size(this_layer % biases), " biases"
+        print *, "Weights are:"
+        print *, this_layer % weights
+      type is (conv2d_layer)
+        print *, "  with kernel of shape", shape(this_layer % kernel)
+        print *, "   and ", size(this_layer % biases), " biases"
+        print *, "Kernel is:"
+        print *, this_layer % kernel
+      class default
+        print *, "  with no parameters"
+    end select
+  end do
+
+end program network_parameters


### PR DESCRIPTION
@Spnetic-5 this PR introduces an example program that shows how to access internal layer parameters (weights and biases). The same approach can be used to access gradients as well, stored as `dw` for weights and `db` for biases.