### PR TITLE
Connect `flatten`, `conv2d`, and `maxpool2d` layers in backward pass

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "neural-fortran"
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT"
 author = "Milan Curcic"
 maintainer = "milancurcic@hey.com"

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -279,7 +279,6 @@ contains
   pure module subroutine backward(self, output)
     class(network), intent(in out) :: self
     real, intent(in) :: output(:)
-    real, allocatable :: gradient(:)
     integer :: n, num_layers
 
     num_layers = size(self % layers)
@@ -292,17 +291,24 @@ contains
         ! Output layer; apply the loss function
         select type(this_layer => self % layers(n) % p)
           type is(dense_layer)
-            gradient = quadratic_derivative(output, this_layer % output)
+            call self % layers(n) % backward( &
+              self % layers(n - 1), &
+              quadratic_derivative(output, this_layer % output) &
+            )
         end select
       else
         ! Hidden layer; take the gradient from the next layer
         select type(next_layer => self % layers(n + 1) % p)
           type is(dense_layer)
-            gradient = next_layer % gradient
+            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+          type is(flatten_layer)
+            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+          type is(conv2d_layer)
+            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+          type is(maxpool2d_layer)
+            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
         end select
       end if
-
-      call self % layers(n) % backward(self % layers(n - 1), gradient)
 
     end do
 


### PR DESCRIPTION
`cnn_mnist` was previously converging to a low ~93% accuracy solution because the convolutional layers were disconnected in the backward pass, so only the output dense layer was being trained. This PR is a WIP that connects these layers. Now that they're connected, `cnn_mnist` doesn't converge due to not yet uncovered issues in the backward passed of `conv2d` and possibly `maxpool2d` layers as well.