### PR TITLE
Added RMSProp Optimizer subroutine

### DIFF
--- a/example/quadratic.f90
+++ b/example/quadratic.f90
@@ -68,7 +68,7 @@ program quadratic_fit
   ypred_rms_prop = [(net_rms_prop % predict([xtest(i)]), i = 1, test_size)]
 
   ! Print the mean squared error
-  print '(" Stochastic gradient descent MSE:", f9.6)', sum((ypred_sgd - ytest)**2) / size(ytest)
+  print '("Stochastic gradient descent MSE:", f9.6)', sum((ypred_sgd - ytest)**2) / size(ytest)
   print '("     Batch gradient descent MSE: ", f9.6)', sum((ypred_batch_sgd - ytest)**2) / size(ytest)
   print '(" Minibatch gradient descent MSE: ", f9.6)', sum((ypred_minibatch_sgd - ytest)**2) / size(ytest)
   print '("                    RMSProp MSE: ", f9.6)', sum((ypred_rms_prop - ytest)**2) / size(ytest)
@@ -169,57 +169,76 @@ contains
     end do
   end subroutine minibatch_gd_optimizer
 
-subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
-  ! RMSprop optimizer for updating weights using root mean square
-  type(network), intent(inout) :: net
-  real, intent(in) :: x(:), y(:)
-  real, intent(in) :: learning_rate, decay_rate
-  integer, intent(in) :: num_epochs
-  integer :: i, j, n, num_layers
-  real, parameter :: epsilon = 1e-8 ! Small constant to avoid division by zero
-  real, allocatable :: rms_weights(:,:), rms_gradients(:,:)
-  real, allocatable :: weights(:,:), gradients(:,:)
-  real, allocatable :: biases(:), bias_gradients(:) 
+  subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
+    ! RMSprop optimizer for updating weights using root mean square
+    type(network), intent(inout) :: net
+    real, intent(in) :: x(:), y(:)
+    real, intent(in) :: learning_rate, decay_rate
+    integer, intent(in) :: num_epochs
+    integer :: i, j, n
+    real, parameter :: epsilon = 1e-8 ! Small constant to avoid division by zero
 
-  print *, "Running RMSprop optimizer..."
+    ! Define a dedicated type to store the RMSprop gradients.
+    ! This is needed because array sizes vary between layers and we need to
+    ! keep track of gradients for each layer over time.
+    ! For now this works only for dense layers.
+    ! We will need to define a similar type for conv2d layers.
+    type :: rms_gradient_dense
+      real, allocatable :: dw(:,:)
+      real, allocatable :: db(:)
+    end type rms_gradient_dense
 
-  num_layers = size(net % layers)
+    type(rms_gradient_dense), allocatable :: rms(:)
 
-  ! Initialize rms_weights, rms_gradients, biases, and bias_gradients arrays
-  allocate(rms_weights(num_layers,1), rms_gradients(num_layers,1))
-  allocate(biases(num_layers), bias_gradients(num_layers))
+    print *, "Running RMSprop optimizer..."
 
-  rms_weights = 0.0
-  rms_gradients = 0.0
-  biases = 0.0
-  bias_gradients = 0.0
+    ! Here we allocate the array or RMS gradient derived types.
+    ! We need one for each dense layer, however we will allocate it to the
+    ! length of all layers as it will make housekeeping easier.
+    allocate(rms(size(net % layers)))
 
-  do n = 1, num_epochs
-    do i = 1, size(x)
-      call net % forward([x(i)])
-      call net % backward([y(i)])
+    do n = 1, num_epochs
 
-      ! Update rms_weights, rms_gradients, biases, and bias_gradients
-      do j = 1, num_layers
+      do i = 1, size(x)
+        call net % forward([x(i)])
+        call net % backward([y(i)])
+      end do
+
+      ! RMSprop update rule
+      do j = 1, size(net % layers)
         select type (this_layer => net % layers(j) % p)
-        type is (dense_layer)   
-          weights = this_layer % weights
-          gradients = this_layer % dw
-          biases = this_layer % biases
-          bias_gradients = this_layer % db
-          rms_weights = decay_rate * rms_weights + (1.0 - decay_rate) * (weights*weights)
-          rms_gradients = decay_rate * rms_gradients + (1.0 - decay_rate) * (gradients*gradients)
-          ! Update weights using RMSprop update rule
-          weights = weights - (learning_rate / sqrt(rms_gradients + epsilon)) * gradients
-          ! Update biases using RMSprop update rule
-          biases = biases - reshape((learning_rate / sqrt(rms_gradients + epsilon)), shape(bias_gradients)) * bias_gradients
+          type is (dense_layer)
+
+            ! If this is our first time here for this layer, allocate the
+            ! internal RMS gradient arrays and initialize them to zero.
+            if (.not. allocated(rms(j) % dw)) then
+              allocate(rms(j) % dw, mold=this_layer % dw)
+              allocate(rms(j) % db, mold=this_layer % db)
+              rms(j) % dw = 0
+              rms(j) % db = 0
+            end if
+
+            ! Update the RMS gradients using the RMSprop moving average rule
+            rms(j) % dw = decay_rate * rms(j) % dw + (1 - decay_rate) * this_layer % dw**2
+            rms(j) % db = decay_rate * rms(j) % db + (1 - decay_rate) * this_layer % db**2
+
+            ! Update weights and biases using the RMSprop update rule
+            this_layer % weights = this_layer % weights - learning_rate &
+              / sqrt(rms(j) % dw + epsilon) * this_layer % dw
+            this_layer % biases = this_layer % biases - learning_rate &
+              / sqrt(rms(j) % db + epsilon) * this_layer % db
+
+            ! We have updated the weights and biases, so we need to reset the
+            ! gradients to zero for the next epoch.
+            this_layer % dw = 0
+            this_layer % db = 0
+
         end select
       end do
+
     end do
-  end do
 
-end subroutine rmsprop_optimizer
-
+  end subroutine rmsprop_optimizer
 
   subroutine shuffle(arr)
     ! Shuffle an array using the Fisher-Yates algorithm.

--- a/example/quadratic.f90
+++ b/example/quadratic.f90
@@ -3,9 +3,10 @@ program quadratic_fit
   ! stochastic gradient descent, batch gradient descent, and minibatch gradient
   ! descent.
   use nf, only: dense, input, network
+  use nf_dense_layer, only: dense_layer
 
   implicit none
-  type(network) :: net_sgd, net_batch_sgd, net_minibatch_sgd
+  type(network) :: net_sgd, net_batch_sgd, net_minibatch_sgd, net_rms_prop
 
   ! Training parameters
   integer, parameter :: num_epochs = 1000
@@ -13,11 +14,12 @@ program quadratic_fit
   integer, parameter :: test_size = 30
   integer, parameter :: batch_size = 10
   real, parameter :: learning_rate = 0.01
+  real, parameter :: decay_rate = 0.9
 
   ! Input and output data
   real, allocatable :: x(:), y(:) ! training data
   real, allocatable :: xtest(:), ytest(:) ! testing data
-  real, allocatable :: ypred_sgd(:), ypred_batch_sgd(:), ypred_minibatch_sgd(:)
+  real, allocatable :: ypred_sgd(:), ypred_batch_sgd(:), ypred_minibatch_sgd(:), ypred_rms_prop(:)
 
   integer :: i, n
 
@@ -42,6 +44,7 @@ program quadratic_fit
   net_sgd = network([input(1), dense(3), dense(1)])
   net_batch_sgd = network([input(1), dense(3), dense(1)])
   net_minibatch_sgd = network([input(1), dense(3), dense(1)])
+  net_rms_prop = network([input(1), dense(3), dense(1)])
 
   ! Print network info to stdout; this will be the same for all three networks.
   call net_sgd % print_info()
@@ -55,15 +58,20 @@ program quadratic_fit
   ! Mini-batch SGD optimizer
   call minibatch_gd_optimizer(net_minibatch_sgd, x, y, learning_rate, num_epochs, batch_size)
 
+  ! RMSProp optimizer
+  call rmsprop_optimizer(net_rms_prop, x, y, learning_rate, num_epochs, decay_rate)
+
   ! Calculate predictions on the test set
   ypred_sgd = [(net_sgd % predict([xtest(i)]), i = 1, test_size)]
   ypred_batch_sgd = [(net_batch_sgd % predict([xtest(i)]), i = 1, test_size)]
   ypred_minibatch_sgd = [(net_minibatch_sgd % predict([xtest(i)]), i = 1, test_size)]
+  ypred_rms_prop = [(net_rms_prop % predict([xtest(i)]), i = 1, test_size)]
 
   ! Print the mean squared error
-  print '("Stochastic gradient descent MSE:", f9.6)', sum((ypred_sgd - ytest)**2) / size(ytest)
+  print '(" Stochastic gradient descent MSE:", f9.6)', sum((ypred_sgd - ytest)**2) / size(ytest)
   print '("     Batch gradient descent MSE: ", f9.6)', sum((ypred_batch_sgd - ytest)**2) / size(ytest)
   print '(" Minibatch gradient descent MSE: ", f9.6)', sum((ypred_minibatch_sgd - ytest)**2) / size(ytest)
+  print '("                    RMSProp MSE: ", f9.6)', sum((ypred_rms_prop - ytest)**2) / size(ytest)
 
 contains
 
@@ -160,6 +168,49 @@ contains
       end do
     end do
   end subroutine minibatch_gd_optimizer
+
+  subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
+    ! RMSprop optimizer for updating weights using root mean square
+    type(network), intent(inout) :: net
+    real, intent(in) :: x(:), y(:)
+    real, intent(in) :: learning_rate, decay_rate
+    integer, intent(in) :: num_epochs
+    integer :: i, j, n
+    real :: epsilon
+    real, allocatable :: rms_weights(:,:), rms_gradients(:,:)
+    real, allocatable :: weights(:,:), gradients(:,:) 
+
+    print *, "Running RMSprop optimizer..."
+
+    ! Initialize rms_weights and rms_gradients arrays
+    allocate(rms_weights(3,1), rms_gradients(3,1))
+
+    rms_weights = 0.0
+    rms_gradients = 0.0
+    epsilon = 1e-8  ! Small constant to avoid division by zero
+
+    do n = 1, num_epochs
+      do i = 1, size(x)
+        call net % forward([x(i)])
+        call net % backward([y(i)])
+
+        ! Update rms_weights and rms_gradients
+        do j = 1, size(net % layers)
+          select type (this_layer => net % layers(j) % p)
+          type is (dense_layer)   
+            weights = this_layer % weights
+            gradients = this_layer % dw
+            rms_weights = decay_rate * rms_weights + (1.0 - decay_rate) * (weights*weights)
+            rms_gradients = decay_rate * rms_gradients + (1.0 - decay_rate) * (gradients*gradients)
+            ! Update weights using RMSprop update rule
+            weights = weights - (learning_rate / sqrt(rms_weights + epsilon)) * gradients
+          end select
+        end do
+      end do
+    end do
+
+  end subroutine rmsprop_optimizer
+
 
   subroutine shuffle(arr)
     ! Shuffle an array using the Fisher-Yates algorithm.

--- a/example/quadratic.f90
+++ b/example/quadratic.f90
@@ -176,7 +176,7 @@ subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
   real, intent(in) :: learning_rate, decay_rate
   integer, intent(in) :: num_epochs
   integer :: i, j, n, num_layers
-  real :: epsilon
+  real, parameter :: epsilon = 1e-8 ! Small constant to avoid division by zero
   real, allocatable :: rms_weights(:,:), rms_gradients(:,:)
   real, allocatable :: weights(:,:), gradients(:,:)
   real, allocatable :: biases(:), bias_gradients(:) 
@@ -193,7 +193,6 @@ subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
   rms_gradients = 0.0
   biases = 0.0
   bias_gradients = 0.0
-  epsilon = 1e-8  ! Small constant to avoid division by zero
 
   do n = 1, num_epochs
     do i = 1, size(x)
@@ -208,13 +207,12 @@ subroutine rmsprop_optimizer(net, x, y, learning_rate, num_epochs, decay_rate)
           gradients = this_layer % dw
           biases = this_layer % biases
           bias_gradients = this_layer % db
-          biases = reshape(biases, shape(bias_gradients))
           rms_weights = decay_rate * rms_weights + (1.0 - decay_rate) * (weights*weights)
           rms_gradients = decay_rate * rms_gradients + (1.0 - decay_rate) * (gradients*gradients)
           ! Update weights using RMSprop update rule
-          weights = weights - (learning_rate / sqrt(rms_weights + epsilon)) * gradients
+          weights = weights - (learning_rate / sqrt(rms_gradients + epsilon)) * gradients
           ! Update biases using RMSprop update rule
-          biases = biases - reshape((learning_rate / sqrt(rms_weights + epsilon)), shape(bias_gradients)) * bias_gradients
+          biases = biases - reshape((learning_rate / sqrt(rms_gradients + epsilon)), shape(bias_gradients)) * bias_gradients
         end select
       end do
     end do


### PR DESCRIPTION
Solves #136 
This pull request adds an implementation of the RMSprop optimizer subroutine to the existing quadratic example. 

Approach:
- Initialized `rms_weights` and `rms_gradients` arrays of appropriate dimensions.
- Added a nested loop over the network layers to update the weights using the RMSprop update rule.
- Calculated `rms_weights` and `rms_gradients` using the decay rate and current weights/gradients.
- Updated the weights using the RMSprop update rule: `weights = weights - (learning_rate / sqrt(rms_weights + epsilon)) * gradients`.
