### PR TITLE
Intrinsic `pack` replaced by pointers in `get_params` and `get_gradients`

### DIFF
--- a/src/nf/nf_conv2d_layer.f90
+++ b/src/nf/nf_conv2d_layer.f90
@@ -89,19 +89,19 @@ module nf_conv2d_layer
         !! Number of parameters
     end function get_num_params
 
-    pure module function get_params(self) result(params)
+    module function get_params(self) result(params)
       !! Return the parameters (weights and biases) of this layer.
       !! The parameters are ordered as weights first, biases second.
-      class(conv2d_layer), intent(in) :: self
+      class(conv2d_layer), intent(in), target :: self
         !! A `conv2d_layer` instance
       real, allocatable :: params(:)
         !! Parameters to get
     end function get_params
 
-    pure module function get_gradients(self) result(gradients)
+    module function get_gradients(self) result(gradients)
       !! Return the gradients of this layer.
       !! The gradients are ordered as weights first, biases second.
-      class(conv2d_layer), intent(in) :: self
+      class(conv2d_layer), intent(in), target :: self
         !! A `conv2d_layer` instance
       real, allocatable :: gradients(:)
         !! Gradients to get

--- a/src/nf/nf_conv2d_layer_submodule.f90
+++ b/src/nf/nf_conv2d_layer_submodule.f90
@@ -193,7 +193,7 @@ contains
     class(conv2d_layer), intent(in), target :: self
     real, allocatable :: params(:)
 
-    real, pointer :: w_(:)
+    real, pointer :: w_(:) => null()
 
     w_(1:size(self % kernel)) => self % kernel
 
@@ -209,7 +209,7 @@ contains
     class(conv2d_layer), intent(in), target :: self
     real, allocatable :: gradients(:)
 
-    real, pointer :: dw_(:)
+    real, pointer :: dw_(:) => null()
 
     dw_(1:size(self % dw)) => self % dw
 
@@ -227,7 +227,7 @@ contains
 
     ! Check that the number of parameters is correct.
     if (size(params) /= self % get_num_params()) then
-       error stop 'conv2d % set_params: Number of parameters does not match'
+      error stop 'conv2d % set_params: Number of parameters does not match'
     end if
 
     ! Reshape the kernel.
@@ -237,10 +237,6 @@ contains
     )
 
     ! Reshape the biases.
-!    self % biases = reshape( &
-!      params(product(shape(self % kernel)) + 1:), &
-!      [self % filters] &
-!    )
     associate(n => product(shape(self % kernel)))
       self % biases = params(n + 1 : n + self % filters)
     end associate

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -110,7 +110,7 @@ module nf_dense_layer
       !! The parameters are ordered as weights first, biases second.
       class(dense_layer), intent(in out) :: self
         !! Dense layer instance
-      real, intent(in) :: params(:)
+      real, intent(in), target :: params(:)
         !! Parameters of this layer
     end subroutine set_params
 

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -87,19 +87,19 @@ module nf_dense_layer
          !! Number of parameters in this layer
     end function get_num_params
 
-    pure module function get_params(self) result(params)
+    module function get_params(self) result(params)
       !! Return the parameters (weights and biases) of this layer.
       !! The parameters are ordered as weights first, biases second.
-      class(dense_layer), intent(in) :: self
+      class(dense_layer), intent(in), target :: self
         !! Dense layer instance
       real, allocatable :: params(:)
         !! Parameters of this layer
     end function get_params
 
-    pure module function get_gradients(self) result(gradients)
+    module function get_gradients(self) result(gradients)
       !! Return the gradients of this layer.
       !! The gradients are ordered as weights first, biases second.
-      class(dense_layer), intent(in) :: self
+      class(dense_layer), intent(in), target :: self
         !! Dense layer instance
       real, allocatable :: gradients(:)
         !! Gradients of this layer

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -70,7 +70,6 @@ contains
     w_(1:size(self % weights)) => self % weights
 
     params = [ &
-!      pack(self % weights, .true.), &
       w_, &
       self % biases &
     ]
@@ -87,7 +86,6 @@ contains
     dw_(1:size(self % dw)) => self % dw
 
     gradients = [ &
-!      pack(self % dw, .true.), &
       dw_, &
       self % db &
     ]
@@ -111,10 +109,13 @@ contains
     )
 
     ! reshape the biases
-    self % biases = reshape( &
-      params(self % input_size * self % output_size + 1:), &
-      [self % output_size] &
-    )
+!    self % biases = reshape( &
+!      params(self % input_size * self % output_size + 1:), &
+!      [self % output_size] &
+!    )
+    associate(n => self % input_size * self % output_size)
+      self % biases = params(n + 1 : n + self % output_size)
+    end associate
 
   end subroutine set_params
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -61,24 +61,34 @@ contains
   end function get_num_params
 
 
-  pure module function get_params(self) result(params)
-    class(dense_layer), intent(in) :: self
+  module function get_params(self) result(params)
+    class(dense_layer), intent(in), target :: self
     real, allocatable :: params(:)
 
+    real, pointer :: w_(:)
+
+    w_(1:size(self % weights)) => self % weights
+
     params = [ &
-      pack(self % weights, .true.), &
+!      pack(self % weights, .true.), &
+      w_, &
       self % biases &
     ]
 
   end function get_params
 
 
-  pure module function get_gradients(self) result(gradients)
-    class(dense_layer), intent(in) :: self
+  module function get_gradients(self) result(gradients)
+    class(dense_layer), intent(in), target :: self
     real, allocatable :: gradients(:)
 
+    real, pointer :: dw_(:)
+
+    dw_(1:size(self % dw)) => self % dw
+
     gradients = [ &
-      pack(self % dw, .true.), &
+!      pack(self % dw, .true.), &
+      dw_, &
       self % db &
     ]
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -65,7 +65,7 @@ contains
     class(dense_layer), intent(in), target :: self
     real, allocatable :: params(:)
 
-    real, pointer :: w_(:)
+    real, pointer :: w_(:) => null()
 
     w_(1:size(self % weights)) => self % weights
 
@@ -81,7 +81,7 @@ contains
     class(dense_layer), intent(in), target :: self
     real, allocatable :: gradients(:)
 
-    real, pointer :: dw_(:)
+    real, pointer :: dw_(:) => null()
 
     dw_(1:size(self % dw)) => self % dw
 
@@ -95,25 +95,21 @@ contains
 
   module subroutine set_params(self, params)
     class(dense_layer), intent(in out) :: self
-    real, intent(in) :: params(:)
+    real, intent(in), target :: params(:)
+
+    real, pointer :: p_(:,:) => null()
 
     ! check if the number of parameters is correct
     if (size(params) /= self % get_num_params()) then
       error stop 'Error: number of parameters does not match'
     end if
 
-    ! reshape the weights
-    self % weights = reshape( &
-      params(:self % input_size * self % output_size), &
-      [self % input_size, self % output_size] &
-    )
-
-    ! reshape the biases
-!    self % biases = reshape( &
-!      params(self % input_size * self % output_size + 1:), &
-!      [self % output_size] &
-!    )
     associate(n => self % input_size * self % output_size)
+      ! reshape the weights
+      p_(1:self % input_size, 1:self % output_size) => params(1 : n)
+      self % weights = p_
+
+      ! reshape the biases
       self % biases = params(n + 1 : n + self % output_size)
     end associate
 

--- a/src/nf/nf_layer.f90
+++ b/src/nf/nf_layer.f90
@@ -129,7 +129,7 @@ module nf_layer
         !! Number of parameters in this layer
     end function get_num_params
 
-    pure module function get_params(self) result(params)
+    module function get_params(self) result(params)
       !! Returns the parameters of this layer.
       class(layer), intent(in) :: self
         !! Layer instance
@@ -137,7 +137,7 @@ module nf_layer
         !! Parameters of this layer
     end function get_params
 
-    pure module function get_gradients(self) result(gradients)
+    module function get_gradients(self) result(gradients)
       !! Returns the gradients of this layer.
       class(layer), intent(in) :: self
         !! Layer instance

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -298,7 +298,7 @@ contains
 
   end function get_num_params
 
-  pure module function get_params(self) result(params)
+  module function get_params(self) result(params)
     class(layer), intent(in) :: self
     real, allocatable :: params(:)
 
@@ -323,7 +323,7 @@ contains
 
   end function get_params
 
-  pure module function get_gradients(self) result(gradients)
+  module function get_gradients(self) result(gradients)
     class(layer), intent(in) :: self
     real, allocatable :: gradients(:)
 

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -159,7 +159,7 @@ module nf_network
       !! Network instance
     end function get_num_params
 
-    pure module function get_params(self) result(params)
+    module function get_params(self) result(params)
       !! Get the network parameters (weights and biases).
       class(network), intent(in) :: self
         !! Network instance
@@ -167,7 +167,7 @@ module nf_network
         !! Network parameters to get
     end function get_params
 
-    pure module function get_gradients(self) result(gradients)
+    module function get_gradients(self) result(gradients)
       class(network), intent(in) :: self
         !! Network instance
       real, allocatable :: gradients(:)

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -496,7 +496,7 @@ contains
   end function get_num_params
 
 
-  pure module function get_params(self) result(params)
+  module function get_params(self) result(params)
     class(network), intent(in) :: self
     real, allocatable :: params(:)
     integer :: n, nstart, nend
@@ -516,7 +516,7 @@ contains
   end function get_params
 
 
-  pure module function get_gradients(self) result(gradients)
+  module function get_gradients(self) result(gradients)
     class(network), intent(in) :: self
     real, allocatable :: gradients(:)
     integer :: n, nstart, nend


### PR DESCRIPTION
This PR proposes to replace some intrinsics `pack` by pointers in `get_params` and `get_gradients`.
Pro: These changes reduced the times of `update` on my own tests by ~30%.
Con: these procedures must be `impure`