### PR TITLE
Mv optimizer from the network level to the layer level

### DIFF
--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -127,7 +127,6 @@ module nf_dense_layer
         !! Dense layer instance
       integer, intent(in) :: input_shape(:)
         !! Shape of the input layer
-
     end subroutine init
 
     module subroutine apply_optimizer(self, batch_size)
@@ -144,8 +143,6 @@ module nf_dense_layer
       class(optimizer_base_type), intent(in), optional :: optimizer
 
     end subroutine set_optimizer
-
-
   end interface
 
 end module nf_dense_layer

--- a/src/nf/nf_dense_layer.f90
+++ b/src/nf/nf_dense_layer.f90
@@ -4,6 +4,7 @@ module nf_dense_layer
   !! It is used internally by the layer type.
   !! It is not intended to be used directly by the user.
 
+  use nf_optimizers, only: optimizer_base_type
   use nf_activation, only: activation_function
   use nf_base_layer, only: base_layer
 
@@ -28,6 +29,8 @@ module nf_dense_layer
     real, allocatable :: db(:) ! bias gradients
 
     class(activation_function), allocatable :: activation
+    class(optimizer_base_type), allocatable :: optimizer_1d
+    class(optimizer_base_type), allocatable :: optimizer_2d
 
   contains
 
@@ -38,6 +41,8 @@ module nf_dense_layer
     procedure :: get_params
     procedure :: init
     procedure :: set_params
+    procedure :: apply_optimizer
+    procedure :: set_optimizer
 
   end type dense_layer
 
@@ -122,7 +127,24 @@ module nf_dense_layer
         !! Dense layer instance
       integer, intent(in) :: input_shape(:)
         !! Shape of the input layer
+
     end subroutine init
+
+    module subroutine apply_optimizer(self, batch_size)
+      class(dense_layer), intent(in out), target :: self
+      integer, intent(in) :: batch_size
+    end subroutine apply_optimizer
+
+    module subroutine set_optimizer(self, optimizer)
+      !! Initialize the layer data structures.
+      !!
+      !! This is a deferred procedure from the `base_layer` abstract type.
+      class(dense_layer), intent(in out) :: self
+        !! Dense layer instance
+      class(optimizer_base_type), intent(in), optional :: optimizer
+
+    end subroutine set_optimizer
+
 
   end interface
 

--- a/src/nf/nf_dense_layer_submodule.f90
+++ b/src/nf/nf_dense_layer_submodule.f90
@@ -152,7 +152,6 @@ contains
 
   end subroutine init
 
-
   module subroutine set_optimizer(self, optimizer)
     class(dense_layer), intent(in out) :: self
     class(optimizer_base_type), intent(in), optional:: optimizer
@@ -192,6 +191,5 @@ contains
 
 
   end subroutine apply_optimizer
-
 
 end submodule nf_dense_layer_submodule

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -254,7 +254,6 @@ module nf_network
       integer, intent(in) :: batch_size
     end subroutine
 
-
   end interface
 
 end module nf_network

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -25,6 +25,8 @@ module nf_network
     procedure :: get_params
     procedure :: print_info
     procedure :: set_params
+    procedure :: apply_optimizer
+    procedure :: set_optimizers
     procedure :: train
     procedure :: update
 
@@ -228,6 +230,17 @@ module nf_network
         !! Set to 1 for a pure stochastic gradient descent (default).
         !! Set to `size(input_data, dim=2)` for a batch gradient descent.
     end subroutine update
+
+    module subroutine set_optimizers(self, optimizer)
+      class(network), intent(in out) :: self
+      class(optimizer_base_type), intent(in) :: optimizer
+    end subroutine set_optimizers
+
+    module subroutine apply_optimizer(self, batch_size)
+      class(network), intent(in out) :: self
+      integer, intent(in) :: batch_size
+    end subroutine
+
 
   end interface
 


### PR DESCRIPTION
As discussed, here is a draft in which I suggst to moved the optimizer  from the network level to the layer level. 

This is just a draft with an implementation for the dense layer only.

Here are the wall clock times using my dataset (with 2 hidden dense layers):

## v0.17.0
* Forward + backward: 4.79s
* Update: 4.59s

## Current PR
* Forward + backward: 4.81s
* Update: 1.40s