### PR TITLE
Generic flatten (2d and 3d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 | Dense (fully-connected) | `dense` | `input1d`, `flatten` | 1 | ✅ | ✅ |
 | Convolutional (2-d) | `conv2d` | `input3d`, `conv2d`, `maxpool2d`, `reshape` | 3 | ✅ | ✅(*) |
 | Max-pooling (2-d) | `maxpool2d` | `input3d`, `conv2d`, `maxpool2d`, `reshape` | 3 | ✅ | ✅ |
-| Flatten | `flatten` | `input3d`, `conv2d`, `maxpool2d`, `reshape` | 1 | ✅ | ✅ |
+| Flatten | `flatten` | `input2d`, `input3d`, `conv2d`, `maxpool2d`, `reshape` | 1 | ✅ | ✅ |
 | Reshape (1-d to 3-d) | `reshape` | `input1d`, `dense`, `flatten` | 3 | ✅ | ✅ |
 
 (*) See Issue [#145](https://github.com/modern-fortran/neural-fortran/issues/145) regarding non-converging CNN training on the MNIST dataset.

--- a/fpm.toml
+++ b/fpm.toml
@@ -4,3 +4,6 @@ license = "MIT"
 author = "Milan Curcic"
 maintainer = "mcurcic@miami.edu"
 copyright = "Copyright 2018-2025, neural-fortran contributors"
+
+[preprocess]
+[preprocess.cpp]

--- a/src/nf/nf_flatten_layer.f90
+++ b/src/nf/nf_flatten_layer.f90
@@ -18,13 +18,20 @@ module nf_flatten_layer
     integer, allocatable :: input_shape(:)
     integer :: output_size
 
-    real, allocatable :: gradient(:,:,:)
+    real, allocatable :: gradient_2d(:,:)
+    real, allocatable :: gradient_3d(:,:,:)
     real, allocatable :: output(:)
 
   contains
 
-    procedure :: backward
-    procedure :: forward
+    procedure :: backward_2d
+    procedure :: backward_3d
+    generic :: backward => backward_2d, backward_3d
+
+    procedure :: forward_2d
+    procedure :: forward_3d
+    generic :: forward => forward_2d, forward_3d
+
     procedure :: init
 
   end type flatten_layer
@@ -39,8 +46,19 @@ module nf_flatten_layer
 
   interface
 
-    pure module subroutine backward(self, input, gradient)
-      !! Apply the backward pass to the flatten layer.
+    pure module subroutine backward_2d(self, input, gradient)
+      !! Apply the backward pass to the flatten layer for 2D input.
+      !! This is a reshape operation from 1-d gradient to 2-d input.
+      class(flatten_layer), intent(in out) :: self
+        !! Flatten layer instance
+      real, intent(in) :: input(:,:)
+        !! Input from the previous layer
+      real, intent(in) :: gradient(:)
+        !! Gradient from the next layer
+    end subroutine backward_2d
+
+    pure module subroutine backward_3d(self, input, gradient)
+      !! Apply the backward pass to the flatten layer for 3D input.
       !! This is a reshape operation from 1-d gradient to 3-d input.
       class(flatten_layer), intent(in out) :: self
         !! Flatten layer instance
@@ -48,17 +66,27 @@ module nf_flatten_layer
         !! Input from the previous layer
       real, intent(in) :: gradient(:)
         !! Gradient from the next layer
-    end subroutine backward
+    end subroutine backward_3d
 
-    pure module subroutine forward(self, input)
-      !! Propagate forward the layer.
+    pure module subroutine forward_2d(self, input)
+      !! Propagate forward the layer for 2D input.
+      !! Calling this subroutine updates the values of a few data components
+      !! of `flatten_layer` that are needed for the backward pass.
+      class(flatten_layer), intent(in out) :: self
+        !! Dense layer instance
+      real, intent(in) :: input(:,:)
+        !! Input from the previous layer
+    end subroutine forward_2d
+
+    pure module subroutine forward_3d(self, input)
+      !! Propagate forward the layer for 3D input.
       !! Calling this subroutine updates the values of a few data components
       !! of `flatten_layer` that are needed for the backward pass.
       class(flatten_layer), intent(in out) :: self
         !! Dense layer instance
       real, intent(in) :: input(:,:,:)
         !! Input from the previous layer
-    end subroutine forward
+    end subroutine forward_3d
 
     module subroutine init(self, input_shape)
       !! Initialize the layer data structures.

--- a/src/nf/nf_flatten_layer.f90
+++ b/src/nf/nf_flatten_layer.f90
@@ -24,14 +24,8 @@ module nf_flatten_layer
 
   contains
 
-    procedure :: backward_2d
-    procedure :: backward_3d
-    generic :: backward => backward_2d, backward_3d
-
-    procedure :: forward_2d
-    procedure :: forward_3d
-    generic :: forward => forward_2d, forward_3d
-
+    procedure :: backward
+    procedure :: forward
     procedure :: init
 
   end type flatten_layer
@@ -46,47 +40,26 @@ module nf_flatten_layer
 
   interface
 
-    pure module subroutine backward_2d(self, input, gradient)
-      !! Apply the backward pass to the flatten layer for 2D input.
-      !! This is a reshape operation from 1-d gradient to 2-d input.
+    pure module subroutine backward(self, input, gradient)
+      !! Apply the backward pass to the flatten layer for 2D and 3D input.
+      !! This is a reshape operation from 1-d gradient to 2-d and 3-d input.
       class(flatten_layer), intent(in out) :: self
         !! Flatten layer instance
-      real, intent(in) :: input(:,:)
+      real, intent(in) :: input(..)
         !! Input from the previous layer
       real, intent(in) :: gradient(:)
         !! Gradient from the next layer
-    end subroutine backward_2d
+    end subroutine backward
 
-    pure module subroutine backward_3d(self, input, gradient)
-      !! Apply the backward pass to the flatten layer for 3D input.
-      !! This is a reshape operation from 1-d gradient to 3-d input.
-      class(flatten_layer), intent(in out) :: self
-        !! Flatten layer instance
-      real, intent(in) :: input(:,:,:)
-        !! Input from the previous layer
-      real, intent(in) :: gradient(:)
-        !! Gradient from the next layer
-    end subroutine backward_3d
-
-    pure module subroutine forward_2d(self, input)
-      !! Propagate forward the layer for 2D input.
+    pure module subroutine forward(self, input)
+      !! Propagate forward the layer for 2D or 3D input.
       !! Calling this subroutine updates the values of a few data components
       !! of `flatten_layer` that are needed for the backward pass.
       class(flatten_layer), intent(in out) :: self
         !! Dense layer instance
-      real, intent(in) :: input(:,:)
+      real, intent(in) :: input(..)
         !! Input from the previous layer
-    end subroutine forward_2d
-
-    pure module subroutine forward_3d(self, input)
-      !! Propagate forward the layer for 3D input.
-      !! Calling this subroutine updates the values of a few data components
-      !! of `flatten_layer` that are needed for the backward pass.
-      class(flatten_layer), intent(in out) :: self
-        !! Dense layer instance
-      real, intent(in) :: input(:,:,:)
-        !! Input from the previous layer
-    end subroutine forward_3d
+    end subroutine forward
 
     module subroutine init(self, input_shape)
       !! Initialize the layer data structures.

--- a/src/nf/nf_flatten_layer_submodule.f90
+++ b/src/nf/nf_flatten_layer_submodule.f90
@@ -15,34 +15,33 @@ contains
   end function flatten_layer_cons
 
 
-  pure module subroutine backward_2d(self, input, gradient)
+  pure module subroutine backward(self, input, gradient)
     class(flatten_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:)
+    real, intent(in) :: input(..)
     real, intent(in) :: gradient(:)
-    self % gradient_2d = reshape(gradient, shape(input))
-  end subroutine backward_2d
+    select rank(input)
+      rank(2)
+        self % gradient_2d = reshape(gradient, shape(input))
+      rank(3)
+        self % gradient_3d = reshape(gradient, shape(input))
+      rank default
+        error stop "Unsupported rank of input"
+    end select
+  end subroutine backward
 
 
-  pure module subroutine backward_3d(self, input, gradient)
+  pure module subroutine forward(self, input)
     class(flatten_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    real, intent(in) :: gradient(:)
-    self % gradient_3d = reshape(gradient, shape(input))
-  end subroutine backward_3d
-
-
-  pure module subroutine forward_2d(self, input)
-    class(flatten_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:)
-    self % output = pack(input, .true.)
-  end subroutine forward_2d
-
-
-  pure module subroutine forward_3d(self, input)
-    class(flatten_layer), intent(in out) :: self
-    real, intent(in) :: input(:,:,:)
-    self % output = pack(input, .true.)
-  end subroutine forward_3d
+    real, intent(in) :: input(..)
+    select rank(input)
+      rank(2)
+        self % output = pack(input, .true.)
+      rank(3)
+        self % output = pack(input, .true.)
+      rank default
+        error stop "Unsupported rank of input"
+    end select
+  end subroutine forward
 
 
   module subroutine init(self, input_shape)

--- a/src/nf/nf_flatten_layer_submodule.f90
+++ b/src/nf/nf_flatten_layer_submodule.f90
@@ -15,19 +15,34 @@ contains
   end function flatten_layer_cons
 
 
-  pure module subroutine backward(self, input, gradient)
+  pure module subroutine backward_2d(self, input, gradient)
+    class(flatten_layer), intent(in out) :: self
+    real, intent(in) :: input(:,:)
+    real, intent(in) :: gradient(:)
+    self % gradient_2d = reshape(gradient, shape(input))
+  end subroutine backward_2d
+
+
+  pure module subroutine backward_3d(self, input, gradient)
     class(flatten_layer), intent(in out) :: self
     real, intent(in) :: input(:,:,:)
     real, intent(in) :: gradient(:)
-    self % gradient = reshape(gradient, shape(input))
-  end subroutine backward
+    self % gradient_3d = reshape(gradient, shape(input))
+  end subroutine backward_3d
 
 
-  pure module subroutine forward(self, input)
+  pure module subroutine forward_2d(self, input)
+    class(flatten_layer), intent(in out) :: self
+    real, intent(in) :: input(:,:)
+    self % output = pack(input, .true.)
+  end subroutine forward_2d
+
+
+  pure module subroutine forward_3d(self, input)
     class(flatten_layer), intent(in out) :: self
     real, intent(in) :: input(:,:,:)
     self % output = pack(input, .true.)
-  end subroutine forward
+  end subroutine forward_3d
 
 
   module subroutine init(self, input_shape)
@@ -37,8 +52,13 @@ contains
     self % input_shape = input_shape
     self % output_size = product(input_shape)
 
-    allocate(self % gradient(input_shape(1), input_shape(2), input_shape(3)))
-    self % gradient = 0
+    if (size(input_shape) == 2) then
+      allocate(self % gradient_2d(input_shape(1), input_shape(2)))
+      self % gradient_2d = 0
+    else if (size(input_shape) == 3) then
+      allocate(self % gradient_3d(input_shape(1), input_shape(2), input_shape(3)))
+      self % gradient_3d = 0
+    end if
 
     allocate(self % output(self % output_size))
     self % output = 0

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -37,8 +37,10 @@ contains
 
       type is(flatten_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d
+        ! Upstream layers permitted: input2d, input3d, conv2d, maxpool2d
         select type(prev_layer => previous % p)
+          type is(input2d_layer)
+            call this_layer % backward(prev_layer % output, gradient)
           type is(input3d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(conv2d_layer)
@@ -168,8 +170,10 @@ contains
 
       type is(flatten_layer)
 
-        ! Upstream layers permitted: input3d, conv2d, maxpool2d, reshape3d
+        ! Upstream layers permitted: input2d, input3d, conv2d, maxpool2d, reshape3d
         select type(prev_layer => input % p)
+          type is(input2d_layer)
+            call this_layer % forward(prev_layer % output)
           type is(input3d_layer)
             call this_layer % forward(prev_layer % output)
           type is(conv2d_layer)

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -135,12 +135,20 @@ contains
         select type(next_layer => self % layers(n + 1) % p)
           type is(dense_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+
           type is(conv2d_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+
           type is(flatten_layer)
-            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+            if (size(self % layers(n) % layer_shape) == 2) then
+              call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient_2d)
+            else
+              call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient_3d)
+            end if
+
           type is(maxpool2d_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+
           type is(reshape3d_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
         end select


### PR DESCRIPTION
I attempted to make a generic `flatten` so that the user doesn't need to do `flatten2d`. It seems like it will work.

In support of `Linear2d` (#197)