### PR TITLE
Embedding Layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(neural-fortran
   src/nf/nf_layer_submodule.f90
   src/nf/nf_linear2d_layer.f90
   src/nf/nf_linear2d_layer_submodule.f90
+  src/nf/nf_embedding_layer.f90
+  src/nf/nf_embedding_layer_submodule.f90
   src/nf/nf_loss.f90
   src/nf/nf_loss_submodule.f90
   src/nf/nf_maxpool2d_layer.f90

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Read the paper [here](https://arxiv.org/abs/1902.06714).
 | Layer type | Constructor name | Supported input layers | Rank of output array | Forward pass | Backward pass |
 |------------|------------------|------------------------|----------------------|--------------|---------------|
 | Input | `input` | n/a | 1, 2, 3 | n/a | n/a |
+| Embedding | `embedding` | n/a | 2 | ✅ | ✅ |
 | Dense (fully-connected) | `dense` | `input1d`, `dense`, `dropout`, `flatten` | 1 | ✅ | ✅ |
 | Dropout | `dropout` | `dense`, `flatten`, `input1d` | 1 | ✅ | ✅ |
 | Convolutional (2-d) | `conv2d` | `input3d`, `conv2d`, `maxpool2d`, `reshape` | 3 | ✅ | ✅(*) |

--- a/src/nf.f90
+++ b/src/nf.f90
@@ -11,7 +11,8 @@ module nf
     linear2d, &
     maxpool2d, &
     reshape, &
-    self_attention
+    self_attention, &
+    embedding
   use nf_loss, only: mse, quadratic
   use nf_metrics, only: corr, maxabs
   use nf_network, only: network

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -58,6 +58,7 @@ module nf_embedding_layer
     end subroutine backward
 
     pure module subroutine positional_encoding(self, pos)
+      !! Sum embedding with positional info (trigonometric, not trianable)
       class(embedding_layer), intent(in out) :: self
       integer, intent(in) :: pos
     end subroutine positional_encoding

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -18,7 +18,6 @@ module nf_embedding_layer
 
     real, allocatable :: weights(:, :)
     real, allocatable :: output(:, :)
-    real, allocatable :: gradient(:, :) ! input gradient
     real, allocatable :: dw(:, :) ! weight gradients
 
   contains

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -15,7 +15,7 @@ module nf_embedding_layer
     !! This layer converts them into a table of shape
     !! (`sequence_length`, `model_dimension`)
     integer :: sequence_length, vocab_size, model_dimension
-    logical :: positional
+    integer :: positional
 
     real, allocatable :: weights(:, :)
     real, allocatable :: output(:, :)
@@ -25,7 +25,8 @@ module nf_embedding_layer
 
     procedure :: backward
     procedure :: forward
-    procedure :: positional_encoding
+    procedure :: positional_trigonometric
+    procedure :: positional_absolute
     procedure :: init
     procedure :: get_num_params
     procedure :: get_params
@@ -37,7 +38,7 @@ module nf_embedding_layer
   interface embedding_layer
     module function embedding_layer_cons(vocab_size, model_dimension, positional) result(res)
       integer, intent(in) :: vocab_size, model_dimension
-      logical, optional :: positional
+      integer, optional :: positional
       type(embedding_layer) :: res
     end function embedding_layer_cons
   end interface embedding_layer
@@ -57,11 +58,17 @@ module nf_embedding_layer
       real, intent(in) :: gradient(:, :)
     end subroutine backward
 
-    pure module subroutine positional_encoding(self, pos)
+    pure module subroutine positional_trigonometric(self, pos)
       !! Sum embedding with positional info (trigonometric, not trianable)
       class(embedding_layer), intent(in out) :: self
       integer, intent(in) :: pos
-    end subroutine positional_encoding
+    end subroutine positional_trigonometric
+
+    pure module subroutine positional_absolute(self, pos)
+      !! Sum embedding with absolute position
+      class(embedding_layer), intent(in out) :: self
+      integer, intent(in) :: pos
+    end subroutine positional_absolute
 
     module subroutine init(self, input_shape)
       class(embedding_layer), intent(in out) :: self

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -15,6 +15,7 @@ module nf_embedding_layer
     !! This layer converts them into a table of shape
     !! (`sequence_length`, `model_dimension`)
     integer :: sequence_length, vocab_size, model_dimension
+    logical :: positional
 
     real, allocatable :: weights(:, :)
     real, allocatable :: output(:, :)
@@ -24,6 +25,7 @@ module nf_embedding_layer
 
     procedure :: backward
     procedure :: forward
+    procedure :: positional_encoding
     procedure :: init
     procedure :: get_num_params
     procedure :: get_params
@@ -33,8 +35,9 @@ module nf_embedding_layer
   end type embedding_layer
 
   interface embedding_layer
-    module function embedding_layer_cons(vocab_size, model_dimension) result(res)
+    module function embedding_layer_cons(vocab_size, model_dimension, positional) result(res)
       integer, intent(in) :: vocab_size, model_dimension
+      logical, optional :: positional
       type(embedding_layer) :: res
     end function embedding_layer_cons
   end interface embedding_layer
@@ -53,6 +56,11 @@ module nf_embedding_layer
       integer, intent(in) :: input(:)
       real, intent(in) :: gradient(:, :)
     end subroutine backward
+
+    pure module subroutine positional_encoding(self, pos)
+      class(embedding_layer), intent(in out) :: self
+      integer, intent(in) :: pos
+    end subroutine positional_encoding
 
     module subroutine init(self, input_shape)
       class(embedding_layer), intent(in out) :: self

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -1,0 +1,77 @@
+module nf_embedding_layer
+
+  use nf_activation, only: activation_function
+  use nf_base_layer, only: base_layer
+
+  implicit none
+
+  private
+  public :: embedding_layer
+
+  type, extends(base_layer) :: embedding_layer
+    integer :: sequence_length, vocab_size, model_dimension
+
+    real, allocatable :: weights(:, :)
+    real, allocatable :: output(:, :)
+    real, allocatable :: gradient(:, :) ! input gradient
+    real, allocatable :: dw(:, :) ! weight gradients
+
+  contains
+
+    procedure :: backward
+    procedure :: forward
+    procedure :: init
+    procedure :: get_num_params
+    procedure :: get_params
+    procedure :: get_gradients
+    procedure :: set_params
+
+  end type embedding_layer
+
+  interface embedding_layer
+    module function embedding_layer_cons(&
+        sequence_length, vocab_size, model_dimension&
+    ) result(res)
+      integer, intent(in) :: sequence_length, vocab_size, model_dimension
+      type(embedding_layer) :: res
+    end function embedding_layer_cons
+  end interface embedding_layer
+
+  interface
+    pure module subroutine forward(self, input)
+      class(embedding_layer), intent(in out) :: self
+      integer, intent(in) :: input(:)
+    end subroutine forward
+
+    pure module subroutine backward(self, input, gradient)
+      class(embedding_layer), intent(in out) :: self
+      integer, intent(in) :: input(:)
+      real, intent(in) :: gradient(:)
+    end subroutine backward
+
+    module subroutine init(self, input_shape)
+      class(embedding_layer), intent(in out) :: self
+      integer, intent(in) :: input_shape(:)
+    end subroutine init
+
+    pure module function get_num_params(self) result(num_params)
+       class(embedding_layer), intent(in) :: self
+       integer :: num_params
+    end function get_num_params
+
+    module function get_params(self) result(params)
+      class(embedding_layer), intent(in), target :: self
+      real, allocatable :: params(:)
+    end function get_params
+
+    module function get_gradients(self) result(gradients)
+      class(embedding_layer), intent(in), target :: self
+      real, allocatable :: gradients(:)
+    end function get_gradients
+
+    module subroutine set_params(self, params)
+      class(embedding_layer), intent(in out) :: self
+      real, intent(in), target :: params(:)
+    end subroutine set_params
+  end interface
+end module nf_embedding_layer

--- a/src/nf/nf_embedding_layer.f90
+++ b/src/nf/nf_embedding_layer.f90
@@ -9,6 +9,11 @@ module nf_embedding_layer
   public :: embedding_layer
 
   type, extends(base_layer) :: embedding_layer
+    !! Embedding Layer
+    !! Stores inputs as a trainable lookup table. Inputs are
+    !! integer indicies in a dictionary of `vocab_size`.
+    !! This layer converts them into a table of shape
+    !! (`sequence_length`, `model_dimension`)
     integer :: sequence_length, vocab_size, model_dimension
 
     real, allocatable :: weights(:, :)
@@ -29,24 +34,25 @@ module nf_embedding_layer
   end type embedding_layer
 
   interface embedding_layer
-    module function embedding_layer_cons(&
-        sequence_length, vocab_size, model_dimension&
-    ) result(res)
-      integer, intent(in) :: sequence_length, vocab_size, model_dimension
+    module function embedding_layer_cons(vocab_size, model_dimension) result(res)
+      integer, intent(in) :: vocab_size, model_dimension
       type(embedding_layer) :: res
     end function embedding_layer_cons
   end interface embedding_layer
 
   interface
     pure module subroutine forward(self, input)
+      !! Get vectors by indicis in the dictionary
       class(embedding_layer), intent(in out) :: self
       integer, intent(in) :: input(:)
     end subroutine forward
 
     pure module subroutine backward(self, input, gradient)
+      !! Update gradient at `input` indices
+      !! dw_i = W_i + d_output_i
       class(embedding_layer), intent(in out) :: self
       integer, intent(in) :: input(:)
-      real, intent(in) :: gradient(:)
+      real, intent(in) :: gradient(:, :)
     end subroutine backward
 
     module subroutine init(self, input_shape)

--- a/src/nf/nf_embedding_layer_submodule.f90
+++ b/src/nf/nf_embedding_layer_submodule.f90
@@ -34,6 +34,8 @@ contains
       index = input(i)
       if (index > size(self % weights, 1)) then
         index = 1
+      elseif (index == 0) then
+        index = 1
       end if
       self % output(i, :) = self % weights(index, :)
     end do

--- a/src/nf/nf_embedding_layer_submodule.f90
+++ b/src/nf/nf_embedding_layer_submodule.f90
@@ -88,7 +88,7 @@ contains
     real, pointer :: w_(:) => null()
 
     w_(1: product(shape(self % weights))) => self % weights
-    params = [w_]
+    params = w_
   end function get_params
 
   module function get_gradients(self) result(gradients)
@@ -97,7 +97,7 @@ contains
     real, pointer :: dw_(:) => null()
 
     dw_(1: product(shape(self % dw))) => self % dw
-    gradients = [dw_]
+    gradients = dw_
   end function get_gradients
 
   module subroutine set_params(self, params)

--- a/src/nf/nf_embedding_layer_submodule.f90
+++ b/src/nf/nf_embedding_layer_submodule.f90
@@ -17,7 +17,6 @@ contains
     self % sequence_length = input_shape(1)
 
     allocate(self % output(self % sequence_length, self % model_dimension))
-    allocate(self % gradient(self % sequence_length, self % vocab_size))
 
     allocate(self % weights(self % vocab_size, self % model_dimension))
     self % weights = 0.1

--- a/src/nf/nf_embedding_submodule.f90
+++ b/src/nf/nf_embedding_submodule.f90
@@ -1,0 +1,97 @@
+submodule(nf_embedding_layer) nf_embedding_layer_submodule
+  use nf_base_layer, only: base_layer
+  implicit none
+contains
+  module function embedding_layer_cons(&
+      sequence_length, vocab_size, model_dimension&
+  ) result(res)
+    integer, intent(in) :: sequence_length, vocab_size, model_dimension
+    type(embedding_layer) :: res
+
+    res % vocab_size = vocab_size
+    res % model_dimension = model_dimension
+    res % sequence_length = sequence_length
+  end function embedding_layer_cons
+
+  module subroutine init(self, input_shape)
+    class(embedding_layer), intent(in out) :: self
+    integer, intent(in) :: input_shape(:)
+
+    allocate(self % output(self % sequence_length, self % model_dimension))
+    allocate(self % gradient(self % sequence_length, self % vocab_size))
+
+    allocate(self % weights(self % vocab_size, self % model_dimension))
+    self % weights = 0.1
+
+    allocate(self % dw(self % vocab_size, self % model_dimension))
+    self % dw = 0.0
+  end subroutine init
+
+  pure module subroutine forward(self, input)
+    class(embedding_layer), intent(in out) :: self
+    integer, intent(in) :: input(:)
+    integer :: i
+
+    do concurrent(i = 1: self % sequence_length)
+      self % output(i, :) = self % weights(input(i), :)
+    end do
+  end subroutine forward
+
+  pure module subroutine backward(self, input, gradient)
+    class(embedding_layer), intent(in out) :: self
+    integer, intent(in) :: input(:)
+    real, intent(in) :: gradient(:)
+    real :: db(self % model_dimension)
+    real :: dw(self % vocab_size, self % model_dimension)
+    integer :: i
+  end subroutine backward
+
+  pure module function get_num_params(self) result(num_params)
+    class(embedding_layer), intent(in) :: self
+    integer :: num_params
+
+    ! Number of weigths times number of biases
+    num_params = self % vocab_size * self % model_dimension + self % model_dimension
+
+  end function get_num_params
+
+
+  module function get_params(self) result(params)
+    class(embedding_layer), intent(in), target :: self
+    real, allocatable :: params(:)
+    real, pointer :: w_(:) => null()
+
+    w_(1: product(shape(self % weights))) => self % weights
+    params = [w_]
+  end function get_params
+
+
+  module function get_gradients(self) result(gradients)
+    class(embedding_layer), intent(in), target :: self
+    real, allocatable :: gradients(:)
+    real, pointer :: dw_(:) => null()
+
+    dw_(1: product(shape(self % dw))) => self % dw
+    gradients = [dw_]
+  end function get_gradients
+
+
+  module subroutine set_params(self, params)
+    class(embedding_layer), intent(in out) :: self
+    real, intent(in), target :: params(:)
+
+    real, pointer :: p_(:,:) => null()
+
+    ! check if the number of parameters is correct
+    if (size(params) /= self % get_num_params()) then
+      error stop 'Error: number of parameters does not match'
+    end if
+
+    associate(n => self % vocab_size * self % model_dimension)
+      ! reshape the weights
+      p_(1:self % vocab_size, 1:self % model_dimension) => params(1 : n)
+      self % weights = p_
+    end associate
+
+  end subroutine set_params
+end submodule nf_embedding_layer_submodule

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -17,7 +17,8 @@ module nf_layer_constructors
     linear2d, &
     maxpool2d, &
     reshape, &
-    self_attention
+    self_attention, &
+    embedding
 
   interface input
 
@@ -222,15 +223,20 @@ module nf_layer_constructors
         !! Resulting layer instance
     end function linear2d
 
-  module function self_attention(num_heads) result(res)
-    !! Rank-2 (sequence_length, out_features) self attention constructor.
-    !! sequence_length and model_dimension are determined at layer initialization, based on the
-    !! output shape of the previous layer.
-    integer, intent(in) :: num_heads
-      !! Number of attention heads
-    type(layer) :: res
-      !! Resulting layer instance
-  end function self_attention
+    module function self_attention(num_heads) result(res)
+      !! Rank-2 (sequence_length, out_features) self attention constructor.
+      !! sequence_length and model_dimension are determined at layer initialization, based on the
+      !! output shape of the previous layer.
+      integer, intent(in) :: num_heads
+        !! Number of attention heads
+      type(layer) :: res
+        !! Resulting layer instance
+    end function self_attention
+
+    module function embedding(sequence_length, vocab_size, model_dimension) result(res)
+      integer, intent(in) :: sequence_length, vocab_size, model_dimension
+      type(layer) :: res
+    end function embedding
 
   end interface
 

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -234,6 +234,14 @@ module nf_layer_constructors
     end function self_attention
 
     module function embedding(sequence_length, vocab_size, model_dimension) result(res)
+      !! Embedding layer constructor.
+      !!
+      !! This layer is for inputting token indices from the dictionary to the network.
+      !! Works as a trainable lookup table that converts each index into a vector.
+      !! Embedding layer must be the first layer in a network.
+      !! `sequence_length`: max len of input sequence
+      !! `vocab_size`: length of token vocabulary
+      !! `model_dimension`: size of target embeddings
       integer, intent(in) :: sequence_length, vocab_size, model_dimension
       type(layer) :: res
     end function embedding

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -233,7 +233,7 @@ module nf_layer_constructors
         !! Resulting layer instance
     end function self_attention
 
-    module function embedding(sequence_length, vocab_size, model_dimension) result(res)
+    module function embedding(sequence_length, vocab_size, model_dimension, positional) result(res)
       !! Embedding layer constructor.
       !!
       !! This layer is for inputting token indices from the dictionary to the network.
@@ -243,6 +243,7 @@ module nf_layer_constructors
       !! `vocab_size`: length of token vocabulary
       !! `model_dimension`: size of target embeddings
       integer, intent(in) :: sequence_length, vocab_size, model_dimension
+      integer, optional, intent(in) :: positional
       type(layer) :: res
     end function embedding
 

--- a/src/nf/nf_layer_constructors_submodule.f90
+++ b/src/nf/nf_layer_constructors_submodule.f90
@@ -12,6 +12,7 @@ submodule(nf_layer_constructors) nf_layer_constructors_submodule
   use nf_reshape_layer, only: reshape3d_layer
   use nf_linear2d_layer, only: linear2d_layer
   use nf_self_attention_layer, only: self_attention_layer
+  use nf_embedding_layer, only: embedding_layer
   use nf_activation, only: activation_function, relu, sigmoid
 
   implicit none
@@ -171,6 +172,7 @@ contains
 
   end function linear2d
 
+
   module function self_attention(num_heads) result(res)
     integer, intent(in) :: num_heads
     type(layer) :: res
@@ -178,5 +180,21 @@ contains
     res % name = 'self_attention'
     allocate(res % p, source=self_attention_layer(num_heads))
   end function self_attention
+
+
+  module function embedding(sequence_length, vocab_size, model_dimension) result(res)
+    integer, intent(in) :: sequence_length, vocab_size, model_dimension
+    type(layer) :: res
+    type(embedding_layer) :: embedding_layer_instance
+
+    embedding_layer_instance = embedding_layer(vocab_size, model_dimension)
+    call embedding_layer_instance % init([sequence_length])
+    res % name = 'embedding'
+    res % layer_shape = [sequence_length, model_dimension]
+    res % input_layer_shape = [integer ::]
+    allocate(res % p, source=embedding_layer_instance)
+    res % initialized = .true.
+
+  end function embedding
 
 end submodule nf_layer_constructors_submodule

--- a/src/nf/nf_layer_constructors_submodule.f90
+++ b/src/nf/nf_layer_constructors_submodule.f90
@@ -182,12 +182,13 @@ contains
   end function self_attention
 
 
-  module function embedding(sequence_length, vocab_size, model_dimension) result(res)
+  module function embedding(sequence_length, vocab_size, model_dimension, positional) result(res)
     integer, intent(in) :: sequence_length, vocab_size, model_dimension
+    integer, optional, intent(in) :: positional
     type(layer) :: res
     type(embedding_layer) :: embedding_layer_instance
 
-    embedding_layer_instance = embedding_layer(vocab_size, model_dimension)
+    embedding_layer_instance = embedding_layer(vocab_size, model_dimension, positional)
     call embedding_layer_instance % init([sequence_length])
     res % name = 'embedding'
     res % layer_shape = [sequence_length, model_dimension]

--- a/src/nf/nf_layer_submodule.f90
+++ b/src/nf/nf_layer_submodule.f90
@@ -12,6 +12,7 @@ submodule(nf_layer) nf_layer_submodule
   use nf_reshape_layer, only: reshape3d_layer
   use nf_linear2d_layer, only: linear2d_layer
   use nf_self_attention_layer, only: self_attention_layer
+  use nf_embedding_layer, only: embedding_layer
   use nf_optimizers, only: optimizer_base_type
 
 contains
@@ -60,6 +61,8 @@ contains
             call this_layer % backward(prev_layer % output, gradient)
           type is(self_attention_layer)
             call this_layer % backward(prev_layer % output, gradient)
+          type is(embedding_layer)
+            call this_layer % backward(prev_layer % output, gradient)
         end select
 
     end select
@@ -80,6 +83,8 @@ contains
         select type(prev_layer => previous % p)
           type is(input2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
+          type is(embedding_layer)
+            call this_layer % backward(prev_layer % output, gradient)
           type is(linear2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(self_attention_layer)
@@ -90,6 +95,8 @@ contains
 
         select type(prev_layer => previous % p)
           type is(input2d_layer)
+            call this_layer % backward(prev_layer % output, gradient)
+          type is(embedding_layer)
             call this_layer % backward(prev_layer % output, gradient)
           type is(linear2d_layer)
             call this_layer % backward(prev_layer % output, gradient)
@@ -254,6 +261,8 @@ contains
         select type(prev_layer => input % p)
           type is(input2d_layer)
             call this_layer % forward(prev_layer % output)
+          type is(embedding_layer)
+            call this_layer % forward(prev_layer % output)
           type is(linear2d_layer)
             call this_layer % forward(prev_layer % output)
           type is(self_attention_layer)
@@ -265,6 +274,8 @@ contains
         ! Upstream layers permitted: input2d, linear2d
         select type(prev_layer => input % p)
           type is(input2d_layer)
+            call this_layer % forward(prev_layer % output)
+          type is(embedding_layer)
             call this_layer % forward(prev_layer % output)
           type is(linear2d_layer)
             call this_layer % forward(prev_layer % output)
@@ -306,6 +317,8 @@ contains
     select type(this_layer => self % p)
 
       type is(input2d_layer)
+        allocate(output, source=this_layer % output)
+      type is(embedding_layer)
         allocate(output, source=this_layer % output)
       type is(linear2d_layer)
         allocate(output, source=this_layer % output)
@@ -425,6 +438,8 @@ contains
         num_params = this_layer % get_num_params()
       type is (self_attention_layer)
         num_params = this_layer % get_num_params()
+      type is (embedding_layer)
+        num_params = this_layer % get_num_params()
       class default
         error stop 'Unknown layer type.'
     end select
@@ -458,6 +473,8 @@ contains
         params = this_layer % get_params()
       type is (self_attention_layer)
         params = this_layer % get_params()
+      type is (embedding_layer)
+        params = this_layer % get_params()
       class default
         error stop 'Unknown layer type.'
     end select
@@ -490,6 +507,8 @@ contains
       type is (linear2d_layer)
         gradients = this_layer % get_gradients()
       type is (self_attention_layer)
+        gradients = this_layer % get_gradients()
+      type is (embedding_layer)
         gradients = this_layer % get_gradients()
       class default
         error stop 'Unknown layer type.'
@@ -547,6 +566,8 @@ contains
         call this_layer % set_params(params)
 
       type is (self_attention_layer)
+        call this_layer % set_params(params)
+      type is (embedding_layer)
         call this_layer % set_params(params)
 
       type is (maxpool2d_layer)

--- a/src/nf/nf_network.f90
+++ b/src/nf/nf_network.f90
@@ -32,17 +32,19 @@ module nf_network
 
     procedure, private :: evaluate_batch_1d
     procedure, private :: forward_1d
+    procedure, private :: forward_1d_int
     procedure, private :: forward_2d
     procedure, private :: forward_3d
     procedure, private :: predict_1d
+    procedure, private :: predict_1d_int
     procedure, private :: predict_2d
     procedure, private :: predict_3d
     procedure, private :: predict_batch_1d
     procedure, private :: predict_batch_3d
 
     generic :: evaluate => evaluate_batch_1d
-    generic :: forward => forward_1d, forward_2d, forward_3d
-    generic :: predict => predict_1d, predict_2d, predict_3d
+    generic :: forward => forward_1d, forward_1d_int, forward_2d, forward_3d
+    generic :: predict => predict_1d, predict_1d_int, predict_2d, predict_3d
     generic :: predict_batch => predict_batch_1d, predict_batch_3d
 
   end type network
@@ -95,6 +97,12 @@ module nf_network
         !! 1-d input data
     end subroutine forward_1d
 
+    module subroutine forward_1d_int(self, input)
+      !! Same as `forward_1d` except `integer`
+      class(network), intent(in out) :: self
+      integer, intent(in) :: input(:)
+    end subroutine forward_1d_int
+
     module subroutine forward_2d(self, input)
       !! Apply a forward pass through the network.
       !!
@@ -136,6 +144,13 @@ module nf_network
       real, allocatable :: res(:)
         !! Output of the network
     end function predict_1d
+
+    module function predict_1d_int(self, input) result(res)
+      !! Same as `predict_1d` except `integer`
+      class(network), intent(in out) :: self
+      integer, intent(in) :: input(:)
+      real, allocatable :: res(:)
+    end function predict_1d_int
 
     module function predict_2d(self, input) result(res)
       !! Return the output of the network given the input 1-d array.

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -11,6 +11,7 @@ submodule(nf_network) nf_network_submodule
   use nf_reshape_layer, only: reshape3d_layer
   use nf_linear2d_layer, only: linear2d_layer
   use nf_self_attention_layer, only: self_attention_layer
+  use nf_embedding_layer, only: embedding_layer
   use nf_layer, only: layer
   use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
   use nf_loss, only: quadratic
@@ -46,7 +47,7 @@ contains
       error stop 'Error: A network must have at least 2 layers.'
 
     ! The first layer must be an input layer
-    if (.not. layers(1) % name == 'input') &
+    if (.not. layers(1) % name == 'input' .and. .not. layers(1) % name == 'embedding') &
       error stop 'Error: First layer in the network must be an input layer.'
 
     !TODO Ensure that the layers are in allowed sequence:
@@ -207,8 +208,11 @@ contains
     integer :: n
 
     ! Set the input array into the input layer
-    select type(input_layer => self % layers(1) % p); type is(input1d_layer)
-      call input_layer % set(input)
+    select type(input_layer => self % layers(1) % p)
+      type is(input1d_layer)
+        call input_layer % set(input)
+      type is(embedding_layer)
+        call input_layer % forward(nint(input))
     end select
 
     do n = 2, size(self % layers)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ foreach(execid
   insert_flatten
   reshape_layer
   multihead_attention_layer
+  embedding_layer
   dense_network
   get_set_network_params
   conv2d_network

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -1,13 +1,16 @@
 program test_embedding_layer
   use iso_fortran_env, only: stderr => error_unit
   use nf_embedding_layer, only: embedding_layer
+  use nf_layer, only: layer
+  use nf_layer_constructors, only: embedding_constructor => embedding
   implicit none
 
   logical :: ok = .true.
+  integer :: sample_input(3) = [2, 1, 3]
 
-  call test_simple(ok)
-  call test_positional_trigonometric(ok)
-  call test_positional_absolute(ok)
+  call test_simple(ok, sample_input)
+  call test_positional_trigonometric(ok, sample_input)
+  call test_positional_absolute(ok, sample_input)
 
   if (ok) then
     print '(a)', 'test_embedding_layer: All tests passed.'
@@ -17,10 +20,10 @@ program test_embedding_layer
   end if
 
 contains
-  subroutine test_simple(ok)
+  subroutine test_simple(ok, sample_input)
     logical, intent(in out) :: ok
+    integer, intent(in) :: sample_input(:)
 
-    integer :: sample_input(3) = [2, 1, 3]
     real :: sample_gradient(3, 2) = reshape([0.1, 0.2, 0.3, 0.4, 0.6, 0.6], [3, 2])
     real :: output_flat(6)
     real :: expected_output_flat(6) = reshape([0.3, 0.1, 0.5, 0.4, 0.2, 0.6], [6])
@@ -48,10 +51,10 @@ contains
     end if
   end subroutine test_simple
 
-  subroutine test_positional_trigonometric(ok)
+  subroutine test_positional_trigonometric(ok, sample_input)
     logical, intent(in out) :: ok
+    integer, intent(in) :: sample_input(:)
 
-    integer :: sample_input(3) = [2, 1, 3]
     real :: output_flat(12)
     real :: expected_output_flat(12) = reshape([&
         0.3, 0.941471, 1.4092975,&
@@ -82,10 +85,10 @@ contains
     end if
   end subroutine test_positional_trigonometric
 
-  subroutine test_positional_absolute(ok)
+  subroutine test_positional_absolute(ok, sample_input)
     logical, intent(in out) :: ok
+    integer, intent(in) :: sample_input(:)
 
-    integer :: sample_input(3) = [2, 1, 3]
     real :: output_flat(12)
     real :: expected_output_flat(12) = reshape([&
         0.3, 1.1, 2.5,&
@@ -115,4 +118,16 @@ contains
       write(stderr, '(a)') 'absolute positional encoding returned incorrect values.. failed'
     end if
   end subroutine test_positional_absolute
+
+  subroutine test_embedding_constructor(ok, sample_input)
+    logical, intent(in out) :: ok
+    integer, intent(in) :: sample_input(:)
+
+    type(layer) :: embedding_constructed
+
+    embedding_constructed = embedding_constructor(sequence_length=3, vocab_size=5, model_dimension=4)
+    embedding_constructed = embedding_constructor(sequence_length=3, vocab_size=5, model_dimension=4, positional=0)
+    embedding_constructed = embedding_constructor(sequence_length=3, vocab_size=5, model_dimension=4, positional=1)
+    embedding_constructed = embedding_constructor(sequence_length=3, vocab_size=5, model_dimension=4, positional=2)
+  end subroutine test_embedding_constructor
 end program test_embedding_layer

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -6,7 +6,8 @@ program test_embedding_layer
   logical :: ok = .true.
 
   call test_simple(ok)
-  call test_positional(ok)
+  call test_positional_trigonometric(ok)
+  call test_positional_absolute(ok)
 
   if (ok) then
     print '(a)', 'test_embedding_layer: All tests passed.'
@@ -47,7 +48,7 @@ contains
     end if
   end subroutine test_simple
 
-  subroutine test_positional(ok)
+  subroutine test_positional_trigonometric(ok)
     logical, intent(in out) :: ok
 
     integer :: sample_input(3) = [2, 1, 3]
@@ -63,7 +64,7 @@ contains
     real :: theta
     integer :: i, pos
 
-    embedding = embedding_layer(vocab_size=5, model_dimension=4, positional=.true.)
+    embedding = embedding_layer(vocab_size=5, model_dimension=4, positional=1)
     call embedding % init([3])
     embedding % weights = reshape([&
         0.1, 0.3, 0.5, 0.7, 0.2,&
@@ -77,7 +78,41 @@ contains
     output_flat = reshape(embedding % output, [12])
     if (.not. all(abs(output_flat - expected_output_flat) <= (1e-06 + 1e-05 * abs(expected_output_flat)))) then
       ok = .false.
-      write(stderr, '(a)') 'positional encoding returned incorrect values.. failed'
+      write(stderr, '(a)') 'trigonometric positional encoding returned incorrect values.. failed'
     end if
-  end subroutine test_positional
+  end subroutine test_positional_trigonometric
+
+  subroutine test_positional_absolute(ok)
+    logical, intent(in out) :: ok
+
+    integer :: sample_input(3) = [2, 1, 3]
+    real :: output_flat(12)
+    real :: expected_output_flat(12) = reshape([&
+        0.3, 1.1, 2.5,&
+        0.3, 1.1, 2.5,&
+        0.3, 1.1, 2.5,&
+        0.3, 1.1, 2.5&
+    ], [12])
+    type(embedding_layer) :: embedding
+
+    real :: theta
+    integer :: i, pos
+
+    embedding = embedding_layer(vocab_size=5, model_dimension=4, positional=2)
+    call embedding % init([3])
+    embedding % weights = reshape([&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2&
+    ], [5, 4])
+
+    call embedding % forward(sample_input)
+
+    output_flat = reshape(embedding % output, [12])
+    if (.not. all(abs(output_flat - expected_output_flat) <= (1e-06 + 1e-05 * abs(expected_output_flat)))) then
+      ok = .false.
+      write(stderr, '(a)') 'absolute positional encoding returned incorrect values.. failed'
+    end if
+  end subroutine test_positional_absolute
 end program test_embedding_layer

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -12,7 +12,7 @@ program test_embedding_layer
     print '(a)', 'test_embedding_layer: All tests passed.'
   else
     write(stderr, '(a)') 'test_embedding_layer: One or more tests failed.'
-    stop 1
+    error stop 1
   end if
 
 contains

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -4,32 +4,9 @@ program test_embedding_layer
   implicit none
 
   logical :: ok = .true.
-  integer :: sample_input(3) = [2, 1, 3]
-  real :: sample_gradient(3, 2) = reshape([0.1, 0.2, 0.3, 0.4, 0.6, 0.6], [3, 2])
-  real :: output_flat(6)
-  real :: expected_output_flat(6) = reshape([0.3, 0.1, 0.5, 0.4, 0.2, 0.6], [6])
-  real :: dw_flat(8)
-  real :: expected_dw_flat(8) = reshape([0.2, 0.1, 0.3, 0., 0.6, 0.4, 0.6, 0.], [8])
-  type(embedding_layer) :: embedding
 
-  embedding = embedding_layer(vocab_size=4, model_dimension=2)
-  call embedding % init([3])
-  embedding % weights = reshape([0.1, 0.3, 0.5, 0.7, 0.2, 0.4, 0.6, 0.8], [4, 2])
-
-  call embedding % forward(sample_input)
-
-  output_flat = reshape(embedding % output, [6])
-  if (.not. all(output_flat.eq.expected_output_flat)) then
-    ok = .false.
-    write(stderr, '(a)') 'forward returned incorrect values.. failed'
-  end if
-
-  call embedding % backward(sample_input, sample_gradient)
-  dw_flat = reshape(embedding % dw, shape(dw_flat))
-  if (.not. all(dw_flat.eq.expected_dw_flat)) then
-    ok = .false.
-    write(stderr, '(a)') 'backward returned incorrect dw values.. failed'
-  end if
+  call test_simple(ok)
+  call test_positional(ok)
 
   if (ok) then
     print '(a)', 'test_embedding_layer: All tests passed.'
@@ -37,4 +14,70 @@ program test_embedding_layer
     write(stderr, '(a)') 'test_embedding_layer: One or more tests failed.'
     stop 1
   end if
+
+contains
+  subroutine test_simple(ok)
+    logical, intent(in out) :: ok
+
+    integer :: sample_input(3) = [2, 1, 3]
+    real :: sample_gradient(3, 2) = reshape([0.1, 0.2, 0.3, 0.4, 0.6, 0.6], [3, 2])
+    real :: output_flat(6)
+    real :: expected_output_flat(6) = reshape([0.3, 0.1, 0.5, 0.4, 0.2, 0.6], [6])
+    real :: dw_flat(8)
+    real :: expected_dw_flat(8) = reshape([0.2, 0.1, 0.3, 0., 0.6, 0.4, 0.6, 0.], [8])
+    type(embedding_layer) :: embedding
+
+    embedding = embedding_layer(vocab_size=4, model_dimension=2)
+    call embedding % init([3])
+    embedding % weights = reshape([0.1, 0.3, 0.5, 0.7, 0.2, 0.4, 0.6, 0.8], [4, 2])
+
+    call embedding % forward(sample_input)
+
+    output_flat = reshape(embedding % output, [6])
+    if (.not. all(output_flat.eq.expected_output_flat)) then
+      ok = .false.
+      write(stderr, '(a)') 'forward returned incorrect values.. failed'
+    end if
+
+    call embedding % backward(sample_input, sample_gradient)
+    dw_flat = reshape(embedding % dw, shape(dw_flat))
+    if (.not. all(dw_flat.eq.expected_dw_flat)) then
+      ok = .false.
+      write(stderr, '(a)') 'backward returned incorrect dw values.. failed'
+    end if
+  end subroutine test_simple
+
+  subroutine test_positional(ok)
+    logical, intent(in out) :: ok
+
+    integer :: sample_input(3) = [2, 1, 3]
+    real :: output_flat(12)
+    real :: expected_output_flat(12) = reshape([&
+        0.3, 0.941471, 1.4092975,&
+        1.3, 0.64030236, 0.08385316,&
+        0.3, 0.10999984, 0.51999867,&
+        1.3, 1.09995, 1.4998&
+    ], [12])
+    type(embedding_layer) :: embedding
+
+    real :: theta
+    integer :: i, pos
+
+    embedding = embedding_layer(vocab_size=5, model_dimension=4, positional=.true.)
+    call embedding % init([3])
+    embedding % weights = reshape([&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2,&
+        0.1, 0.3, 0.5, 0.7, 0.2&
+    ], [5, 4])
+
+    call embedding % forward(sample_input)
+
+    output_flat = reshape(embedding % output, [12])
+    if (.not. all(abs(output_flat - expected_output_flat) <= (1e-06 + 1e-05 * abs(expected_output_flat)))) then
+      ok = .false.
+      write(stderr, '(a)') 'positional encoding returned incorrect values.. failed'
+    end if
+  end subroutine test_positional
 end program test_embedding_layer

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -1,0 +1,14 @@
+program test_embedding_layer
+  use iso_fortran_env, only: stderr => error_unit
+  use nf_embedding_layer, only: embedding_layer
+  implicit none
+
+  logical :: ok = .true.
+  integer :: sample_input(3) = [2, 1, 3]
+  type(embedding_layer) :: embedding
+
+  embedding = embedding_layer(sequence_length=3, vocab_size=4, model_dimension=2)
+  call embedding % init([0])
+  embedding % weights = reshape([0.1, 0.3, 0.5, 0.7, 0.2, 0.4, 0.6, 0.8], [4, 2])
+  call embedding % forward(sample_input)
+end program test_embedding_layer

--- a/test/test_embedding_layer.f90
+++ b/test/test_embedding_layer.f90
@@ -5,10 +5,36 @@ program test_embedding_layer
 
   logical :: ok = .true.
   integer :: sample_input(3) = [2, 1, 3]
+  real :: sample_gradient(3, 2) = reshape([0.1, 0.2, 0.3, 0.4, 0.6, 0.6], [3, 2])
+  real :: output_flat(6)
+  real :: expected_output_flat(6) = reshape([0.3, 0.1, 0.5, 0.4, 0.2, 0.6], [6])
+  real :: dw_flat(8)
+  real :: expected_dw_flat(8) = reshape([0.2, 0.1, 0.3, 0., 0.6, 0.4, 0.6, 0.], [8])
   type(embedding_layer) :: embedding
 
-  embedding = embedding_layer(sequence_length=3, vocab_size=4, model_dimension=2)
-  call embedding % init([0])
+  embedding = embedding_layer(vocab_size=4, model_dimension=2)
+  call embedding % init([3])
   embedding % weights = reshape([0.1, 0.3, 0.5, 0.7, 0.2, 0.4, 0.6, 0.8], [4, 2])
+
   call embedding % forward(sample_input)
+
+  output_flat = reshape(embedding % output, [6])
+  if (.not. all(output_flat.eq.expected_output_flat)) then
+    ok = .false.
+    write(stderr, '(a)') 'forward returned incorrect values.. failed'
+  end if
+
+  call embedding % backward(sample_input, sample_gradient)
+  dw_flat = reshape(embedding % dw, shape(dw_flat))
+  if (.not. all(dw_flat.eq.expected_dw_flat)) then
+    ok = .false.
+    write(stderr, '(a)') 'backward returned incorrect dw values.. failed'
+  end if
+
+  if (ok) then
+    print '(a)', 'test_embedding_layer: All tests passed.'
+  else
+    write(stderr, '(a)') 'test_embedding_layer: One or more tests failed.'
+    stop 1
+  end if
 end program test_embedding_layer


### PR DESCRIPTION
# Input Embeddings Lookup Table (Trainable
## Core
In Natural Language Processing input data is often encoded as indices of tokens in a vocabulary. Those indices are converted into vectors using weights which are trainable.
In theory, similar behaviour can be achieved by spreading input data by the desired size of vectors and then put through `input2d` and `linear2d` layers. However, it is very inefficient as we'll have to do `matmul` each time instead of simply getting an element by indices.
So, I created the layer that does it efficiently. It does not have a gradient as it is intended as an input layer. But it is trainable (`get_params`, `get_gradients` and `set_params`).

## Positional
Apart from this core functionality, I also added positional encoding (output vectors + positions assigned to sin/cos waves). This will be needed for transformers.

## Python Reference
[Here](https://github.com/OneAdder/neural-fortran-references/blob/main/embedding.py): `torch.nn.Embedding` and a custom function for positional encoding.