### PR TITLE
Fc2d layer

### DIFF
--- a/example/simple_2d_mlp.f90
+++ b/example/simple_2d_mlp.f90
@@ -1,0 +1,35 @@
+program simple
+  use nf, only: dense, fc2d, flatten, linear2d, input, network, sgd, relu, tanhf
+  implicit none
+  type(network) :: net
+  real, allocatable :: x(:, :), y(:)
+  integer, parameter :: num_iterations = 25
+  integer :: n
+
+  print '("Simple")'
+  print '(60("="))'
+
+  net = network([ &
+    input(4, 5), &
+    fc2d(3, 2, activation=relu()), &
+    flatten(), &
+    dense(4, activation=tanhf()) &
+  ])
+
+  call net % print_info()
+
+  allocate(x(4, 5))
+  call random_number(x)
+  y = [0.123456, 0.246802, 0.9, 0.001]
+
+  do n = 0, num_iterations
+
+    call net % forward(x)
+    call net % backward(y)
+    call net % update(optimizer=sgd(learning_rate=0.05))
+
+    if (mod(n, 5) == 0) print *, n, net % predict(x)
+
+  end do
+
+end program simple

--- a/src/nf.f90
+++ b/src/nf.f90
@@ -11,7 +11,8 @@ module nf
     linear2d, &
     maxpool2d, &
     reshape, &
-    self_attention
+    self_attention, &
+    fc2d
   use nf_loss, only: mse, quadratic
   use nf_metrics, only: corr, maxabs
   use nf_network, only: network

--- a/src/nf/nf_fc2d_layer.f90
+++ b/src/nf/nf_fc2d_layer.f90
@@ -1,0 +1,95 @@
+module nf_fc2d_layer
+  use iso_fortran_env, only: stderr => error_unit
+  use nf_activation, only: activation_function
+  use nf_base_layer, only: base_layer
+  use nf_linear2d_layer, only: linear2d_layer
+
+  implicit none
+
+  private
+  public :: fc2d_layer
+
+  type, extends(base_layer) :: fc2d_layer
+    integer :: sequence_length, hidden_size, model_dimension
+
+    type(linear2d_layer) :: in_proj
+    type(linear2d_layer) :: out_proj
+
+    class(activation_function), allocatable :: activation
+
+    real, allocatable :: gradient(:, :)
+    real, allocatable :: in_proj_input(:, :)
+    real, allocatable :: out_proj_input(:, :)
+
+    real, allocatable :: output(:, :)
+
+  contains
+!    procedure :: backward
+    procedure :: forward
+!    procedure :: get_num_params
+!    procedure :: get_params
+!    procedure :: get_gradients
+!    procedure :: set_params
+    procedure :: init
+  end type fc2d_layer
+
+  interface fc2d_layer
+    module function fc2d_layer_cons(hidden_size, activation) result(res)
+      !! This function returns the `fc2d_layer` instance.
+      integer, intent(in) :: hidden_size
+      class(activation_function), intent(in) :: activation
+      type(fc2d_layer) :: res
+    end function fc2d_layer_cons
+  end interface fc2d_layer
+
+contains
+  module function fc2d_layer_cons(hidden_size, activation) result(res)
+    !! This function returns the `fc2d_layer` instance.
+    integer, intent(in) :: hidden_size
+    class(activation_function), intent(in) :: activation
+    type(fc2d_layer) :: res
+
+    res % hidden_size = hidden_size
+    res % activation_name = activation % get_name()
+    allocate(res % activation, source = activation)
+  end function fc2d_layer_cons
+
+  module subroutine init(self, input_shape)
+    class(fc2d_layer), intent(in out) :: self
+    integer, intent(in) :: input_shape(:)
+
+    if (size(input_shape) /= 2) then
+      error stop "fc2d_layer accepts 2D input"
+    end if
+
+    self % sequence_length = input_shape(1)
+    self % model_dimension = input_shape(2)
+
+    self % in_proj = linear2d_layer(self % hidden_size)
+    call self % in_proj % init([self % sequence_length, self % model_dimension])
+
+    self % out_proj = linear2d_layer(self % model_dimension)
+    call self % out_proj % init([self % sequence_length, self % hidden_size])
+
+    allocate(self % in_proj_input(self % sequence_length, self % model_dimension))
+    allocate(self % out_proj_input(self % sequence_length, self % hidden_size))
+
+    allocate(self % output(self % sequence_length, self % model_dimension))
+  end subroutine init
+
+  pure module subroutine forward(self, input)
+    class(fc2d_layer), intent(in out) :: self
+    real, intent(in) :: input(:, :)
+    integer :: i
+
+    self % in_proj_input = input
+    call self % in_proj % forward(input)
+
+    do concurrent(i = 1: self % sequence_length)
+      self % out_proj_input(i, :) = self % activation % eval_1d(self % in_proj % output(i, :))
+    end do
+
+    call self % out_proj % forward(self % out_proj_input)
+    self % output = self % out_proj % output
+  end subroutine forward
+end module nf_fc2d_layer

--- a/src/nf/nf_fc2d_layer.f90
+++ b/src/nf/nf_fc2d_layer.f90
@@ -10,6 +10,8 @@ module nf_fc2d_layer
   public :: fc2d_layer
 
   type, extends(base_layer) :: fc2d_layer
+    !! Fully Connected 2D Layer
+    !! Two Linear layers with an activation function in between
     integer :: sequence_length, hidden_size, model_dimension
 
     type(linear2d_layer) :: in_proj
@@ -42,133 +44,41 @@ module nf_fc2d_layer
     end function fc2d_layer_cons
   end interface fc2d_layer
 
-contains
-  module function fc2d_layer_cons(hidden_size, activation) result(res)
-    !! This function returns the `fc2d_layer` instance.
-    integer, intent(in) :: hidden_size
-    class(activation_function), intent(in) :: activation
-    type(fc2d_layer) :: res
+  interface
+    module subroutine init(self, input_shape)
+      class(fc2d_layer), intent(in out) :: self
+      integer, intent(in) :: input_shape(:)
+    end subroutine init
 
-    res % hidden_size = hidden_size
-    res % activation_name = activation % get_name()
-    ! FIXME: implement correct derivative for `softmax`
-    if (res % activation_name == 'softmax') then
-      write(stderr, '(a)') '`softmax` activation is temporarily unavailable'
-      error stop 1
-    end if
-    allocate(res % activation, source = activation)
-  end function fc2d_layer_cons
+    pure module subroutine forward(self, input)
+      class(fc2d_layer), intent(in out) :: self
+      real, intent(in) :: input(:, :)
+    end subroutine forward
 
-  module subroutine init(self, input_shape)
-    class(fc2d_layer), intent(in out) :: self
-    integer, intent(in) :: input_shape(:)
+    pure module subroutine backward(self, input, gradient)
+      class(fc2d_layer), intent(in out) :: self
+      real, intent(in) :: input(:, :)
+      real, intent(in) :: gradient(:, :)
+    end subroutine backward
 
-    if (size(input_shape) /= 2) then
-      error stop "fc2d_layer accepts 2D input"
-    end if
+    elemental module function get_num_params(self) result(num_params)
+      class(fc2d_layer), intent(in) :: self
+      integer :: num_params
+    end function get_num_params
 
-    self % sequence_length = input_shape(1)
-    self % model_dimension = input_shape(2)
+    module function get_params(self) result(params)
+      class(fc2d_layer), intent(in) :: self
+      real, allocatable :: params(:)
+    end function get_params
 
-    self % in_proj = linear2d_layer(self % hidden_size)
-    call self % in_proj % init([self % sequence_length, self % model_dimension])
+    module function get_gradients(self) result(gradients)
+      class(fc2d_layer), intent(in), target :: self
+      real, allocatable :: gradients(:)
+    end function get_gradients
 
-    self % out_proj = linear2d_layer(self % model_dimension)
-    call self % out_proj % init([self % sequence_length, self % hidden_size])
-
-    allocate(self % in_proj_input(self % sequence_length, self % model_dimension))
-    allocate(self % out_proj_input(self % sequence_length, self % hidden_size))
-
-    allocate(self % output(self % sequence_length, self % model_dimension))
-
-    allocate(self % gradient, mold=self % in_proj % gradient)
-  end subroutine init
-
-  pure module subroutine forward(self, input)
-    class(fc2d_layer), intent(in out) :: self
-    real, intent(in) :: input(:, :)
-    integer :: i
-
-    self % in_proj_input = input
-    call self % in_proj % forward(input)
-
-    do concurrent(i = 1: self % sequence_length)
-      self % out_proj_input(i, :) = self % activation % eval_1d(self % in_proj % output(i, :))
-    end do
-
-    call self % out_proj % forward(self % out_proj_input)
-    self % output = self % out_proj % output
-  end subroutine forward
-
-  pure module subroutine backward(self, input, gradient)
-    class(fc2d_layer), intent(in out) :: self
-    real, intent(in) :: input(:, :)
-    real, intent(in) :: gradient(:, :)
-    integer :: i
-
-    call self % out_proj % backward(self % out_proj_input, gradient)
-    do concurrent(i = 1: self % sequence_length)
-      self % out_proj % gradient(i, :) = self % out_proj % gradient(i, :) &
-      * (self % activation % eval_1d_prime(self % in_proj % output(i, :)))
-    end do
-    call self % in_proj % backward(self % in_proj_input, self % out_proj % gradient)
-
-    self % gradient = self % in_proj % gradient
-  end subroutine backward
-
-  elemental module function get_num_params(self) result(num_params)
-    class(fc2d_layer), intent(in) :: self
-    integer :: num_params
-
-    num_params = self % in_proj % get_num_params() + self % out_proj % get_num_params()
-  end function get_num_params
-
-  module function get_params(self) result(params)
-    class(fc2d_layer), intent(in) :: self
-    real, allocatable :: params(:)
-
-    params = [&
-        self % in_proj % weights,&
-        self % out_proj % weights,&
-        self % in_proj % biases,&
-        self % out_proj % biases&
-    ]
-  end function get_params
-
-  module function get_gradients(self) result(gradients)
-    class(fc2d_layer), intent(in), target :: self
-    real, allocatable :: gradients(:)
-
-    gradients = [ &
-        self % in_proj % dw,&
-        self % out_proj % dw,&
-        self % in_proj % db,&
-        self % out_proj % db&
-    ]
-  end function get_gradients
-
-  module subroutine set_params(self, params)
-    class(fc2d_layer), intent(in out) :: self
-    real, intent(in) :: params(:)
-    integer :: i, j, window
-
-    ! check if the number of parameters is correct
-    if (size(params) /= self % get_num_params()) then
-      error stop 'Error: number of parameters does not match'
-    end if
-
-    ! FIXME: looks clumsy, better ideas?
-    associate (transformation => self % model_dimension * self % hidden_size)
-      self % in_proj % weights = reshape(params(1: transformation), shape(self % in_proj % weights))
-      self % out_proj % weights = reshape(&
-          params(transformation + 1: 2 * transformation),&
-          shape(self % out_proj % weights)&
-      )
-      self % in_proj % biases = params(2 * transformation + 1: 2 * transformation + self % hidden_size)
-      self % out_proj % biases = params(&
-          2 * transformation + self % hidden_size + 1: &
-          2 * transformation + self % hidden_size + self % model_dimension&
-      )
-    end associate
-  end subroutine set_params
+    module subroutine set_params(self, params)
+      class(fc2d_layer), intent(in out) :: self
+      real, intent(in) :: params(:)
+    end subroutine set_params
+  end interface
 end module nf_fc2d_layer

--- a/src/nf/nf_fc2d_layer.f90
+++ b/src/nf/nf_fc2d_layer.f90
@@ -12,7 +12,7 @@ module nf_fc2d_layer
   type, extends(base_layer) :: fc2d_layer
     !! Fully Connected 2D Layer
     !! Two Linear layers with an activation function in between
-    integer :: sequence_length, hidden_size, model_dimension
+    integer :: sequence_length, model_dimension, hidden_size, output_size
 
     type(linear2d_layer) :: in_proj
     type(linear2d_layer) :: out_proj
@@ -36,9 +36,9 @@ module nf_fc2d_layer
   end type fc2d_layer
 
   interface fc2d_layer
-    module function fc2d_layer_cons(hidden_size, activation) result(res)
+    module function fc2d_layer_cons(hidden_size, output_size, activation) result(res)
       !! This function returns the `fc2d_layer` instance.
-      integer, intent(in) :: hidden_size
+      integer, intent(in) :: hidden_size, output_size
       class(activation_function), intent(in) :: activation
       type(fc2d_layer) :: res
     end function fc2d_layer_cons

--- a/src/nf/nf_fc2d_layer_submodule.f90
+++ b/src/nf/nf_fc2d_layer_submodule.f90
@@ -1,0 +1,138 @@
+submodule(nf_fc2d_layer) nf_fc2d_layer_submodule
+  use nf_activation, only: activation_function
+  use nf_base_layer, only: base_layer
+  use nf_linear2d_layer, only: linear2d_layer
+
+  implicit none
+
+contains
+  module function fc2d_layer_cons(hidden_size, activation) result(res)
+    !! This function returns the `fc2d_layer` instance.
+    integer, intent(in) :: hidden_size
+    class(activation_function), intent(in) :: activation
+    type(fc2d_layer) :: res
+
+    res % hidden_size = hidden_size
+    res % activation_name = activation % get_name()
+    ! FIXME: implement correct derivative for `softmax`
+    if (res % activation_name == 'softmax') then
+      write(stderr, '(a)') '`softmax` activation is temporarily unavailable'
+      error stop 1
+    end if
+    allocate(res % activation, source = activation)
+  end function fc2d_layer_cons
+
+  module subroutine init(self, input_shape)
+    class(fc2d_layer), intent(in out) :: self
+    integer, intent(in) :: input_shape(:)
+
+    if (size(input_shape) /= 2) then
+      error stop "fc2d_layer accepts 2D input"
+    end if
+
+    self % sequence_length = input_shape(1)
+    self % model_dimension = input_shape(2)
+
+    self % in_proj = linear2d_layer(self % hidden_size)
+    call self % in_proj % init([self % sequence_length, self % model_dimension])
+
+    self % out_proj = linear2d_layer(self % model_dimension)
+    call self % out_proj % init([self % sequence_length, self % hidden_size])
+
+    allocate(self % in_proj_input(self % sequence_length, self % model_dimension))
+    allocate(self % out_proj_input(self % sequence_length, self % hidden_size))
+
+    allocate(self % output(self % sequence_length, self % model_dimension))
+
+    allocate(self % gradient, mold=self % in_proj % gradient)
+  end subroutine init
+
+  pure module subroutine forward(self, input)
+    class(fc2d_layer), intent(in out) :: self
+    real, intent(in) :: input(:, :)
+    integer :: i
+
+    self % in_proj_input = input
+    call self % in_proj % forward(input)
+
+    do concurrent(i = 1: self % sequence_length)
+      self % out_proj_input(i, :) = self % activation % eval_1d(self % in_proj % output(i, :))
+    end do
+
+    call self % out_proj % forward(self % out_proj_input)
+    self % output = self % out_proj % output
+  end subroutine forward
+
+  pure module subroutine backward(self, input, gradient)
+    class(fc2d_layer), intent(in out) :: self
+    real, intent(in) :: input(:, :)
+    real, intent(in) :: gradient(:, :)
+    integer :: i
+
+    call self % out_proj % backward(self % out_proj_input, gradient)
+    ! d_output/d_activation = d_output/d_output_proj * d/d_activation
+    do concurrent(i = 1: self % sequence_length)
+      self % out_proj % gradient(i, :) = &
+          self % out_proj % gradient(i, :) &
+          * (self % activation % eval_1d_prime(self % in_proj % output(i, :)))
+    end do
+    call self % in_proj % backward(self % in_proj_input, self % out_proj % gradient)
+
+    self % gradient = self % in_proj % gradient
+  end subroutine backward
+
+  elemental module function get_num_params(self) result(num_params)
+    class(fc2d_layer), intent(in) :: self
+    integer :: num_params
+
+    num_params = self % in_proj % get_num_params() + self % out_proj % get_num_params()
+  end function get_num_params
+
+  module function get_params(self) result(params)
+    class(fc2d_layer), intent(in) :: self
+    real, allocatable :: params(:)
+
+    params = [&
+        self % in_proj % weights,&
+        self % out_proj % weights,&
+        self % in_proj % biases,&
+        self % out_proj % biases&
+    ]
+  end function get_params
+
+  module function get_gradients(self) result(gradients)
+    class(fc2d_layer), intent(in), target :: self
+    real, allocatable :: gradients(:)
+
+    gradients = [ &
+        self % in_proj % dw,&
+        self % out_proj % dw,&
+        self % in_proj % db,&
+        self % out_proj % db&
+    ]
+  end function get_gradients
+
+  module subroutine set_params(self, params)
+    class(fc2d_layer), intent(in out) :: self
+    real, intent(in) :: params(:)
+
+    ! check if the number of parameters is correct
+    if (size(params) /= self % get_num_params()) then
+      error stop 'Error: number of parameters does not match'
+    end if
+
+    ! FIXME: looks clumsy, better ideas?
+    associate (transformation => self % model_dimension * self % hidden_size)
+      self % in_proj % weights = reshape(params(1: transformation), shape(self % in_proj % weights))
+      self % out_proj % weights = reshape(&
+          params(transformation + 1: 2 * transformation),&
+          shape(self % out_proj % weights)&
+      )
+      self % in_proj % biases = params(2 * transformation + 1: 2 * transformation + self % hidden_size)
+      self % out_proj % biases = params(&
+          2 * transformation + self % hidden_size + 1: &
+          2 * transformation + self % hidden_size + self % model_dimension&
+      )
+    end associate
+  end subroutine set_params
+end submodule nf_fc2d_layer_submodule

--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -17,7 +17,8 @@ module nf_layer_constructors
     linear2d, &
     maxpool2d, &
     reshape, &
-    self_attention
+    self_attention, &
+    fc2d
 
   interface input
 
@@ -222,16 +223,21 @@ module nf_layer_constructors
         !! Resulting layer instance
     end function linear2d
 
-  module function self_attention(num_heads) result(res)
-    !! Rank-2 (sequence_length, out_features) self attention constructor.
-    !! sequence_length and model_dimension are determined at layer initialization, based on the
-    !! output shape of the previous layer.
-    integer, intent(in) :: num_heads
-      !! Number of attention heads
-    type(layer) :: res
-      !! Resulting layer instance
-  end function self_attention
+    module function self_attention(num_heads) result(res)
+      !! Rank-2 (sequence_length, out_features) self attention constructor.
+      !! sequence_length and model_dimension are determined at layer initialization, based on the
+      !! output shape of the previous layer.
+      integer, intent(in) :: num_heads
+        !! Number of attention heads
+      type(layer) :: res
+        !! Resulting layer instance
+    end function self_attention
 
+    module function fc2d(hidden_size, output_size, activation) result(res)
+      integer, intent(in) :: hidden_size, output_size
+      class(activation_function), intent(in) :: activation
+      type(layer) :: res
+    end function fc2d
   end interface
 
 end module nf_layer_constructors

--- a/src/nf/nf_layer_constructors_submodule.f90
+++ b/src/nf/nf_layer_constructors_submodule.f90
@@ -12,6 +12,7 @@ submodule(nf_layer_constructors) nf_layer_constructors_submodule
   use nf_reshape_layer, only: reshape3d_layer
   use nf_linear2d_layer, only: linear2d_layer
   use nf_self_attention_layer, only: self_attention_layer
+  use nf_fc2d_layer, only: fc2d_layer
   use nf_activation, only: activation_function, relu, sigmoid
 
   implicit none
@@ -178,5 +179,14 @@ contains
     res % name = 'self_attention'
     allocate(res % p, source=self_attention_layer(num_heads))
   end function self_attention
+
+  module function fc2d(hidden_size, output_size, activation) result(res)
+    integer, intent(in) :: hidden_size, output_size
+    class(activation_function), intent(in) :: activation
+    type(layer) :: res
+
+    res % name = 'fc2d'
+    allocate(res % p, source=fc2d_layer(hidden_size, output_size, activation))
+  end function fc2d
 
 end submodule nf_layer_constructors_submodule

--- a/src/nf/nf_network_submodule.f90
+++ b/src/nf/nf_network_submodule.f90
@@ -11,6 +11,7 @@ submodule(nf_network) nf_network_submodule
   use nf_reshape_layer, only: reshape3d_layer
   use nf_linear2d_layer, only: linear2d_layer
   use nf_self_attention_layer, only: self_attention_layer
+  use nf_fc2d_layer, only: fc2d_layer
   use nf_layer, only: layer
   use nf_layer_constructors, only: conv2d, dense, flatten, input, maxpool2d, reshape
   use nf_loss, only: quadratic
@@ -162,6 +163,8 @@ contains
           type is(linear2d_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
           type is(self_attention_layer)
+            call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
+          type is(fc2d_layer)
             call self % layers(n) % backward(self % layers(n - 1), next_layer % gradient)
         end select
       end if

--- a/test/test_fc2d_layer.f90
+++ b/test/test_fc2d_layer.f90
@@ -73,7 +73,12 @@ contains
   subroutine init_weigths(fc)
     type(fc2d_layer) :: fc
     fc % in_proj % weights = reshape(&
-        [0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.5, 0.1, 0.2, 0.4, 0.5, 0.1, 0.3, 0.4, 0.5, 0.2, 0.3, 0.4, 0.5],&
+        [&
+            0.1, 0.2, 0.3, 0.4, 0.1,&
+            0.2, 0.3, 0.5, 0.1, 0.2,&
+            0.4, 0.5, 0.1, 0.3, 0.4,&
+            0.5, 0.2, 0.3, 0.4, 0.5&
+        ],&
         [4, 5]&
     )
     fc % in_proj % biases = 0.11
@@ -136,7 +141,7 @@ contains
     gradient_shape = shape(fc % gradient)
     if (.not. all(gradient_shape.eq.expected_gradient_shape)) then
       ok = .false.
-      write(stderr, '(aa)') 'backward returned incorrect gradient shape.. failed', fc % activation % get_name()
+      write(stderr, '(aa)') 'backward returned incorrect gradient shape.. failed for', fc % activation % get_name()
     end if
     gradient_flat = reshape(fc % gradient, shape(gradient_flat))
     if (.not. allclose(gradient_flat, expected_gradient_flat)) then

--- a/test/test_fc2d_layer.f90
+++ b/test/test_fc2d_layer.f90
@@ -1,7 +1,7 @@
 program test_fc2d_layer
   use iso_fortran_env, only: stderr => error_unit
   use nf_fc2d_layer, only: fc2d_layer
-  use nf, only: relu
+  use nf, only: activation_function, relu, tanhf, sigmoid, softplus
   implicit none
 
   logical :: ok = .true.
@@ -11,20 +11,53 @@ program test_fc2d_layer
   real :: sample_gradient(3, 4) = reshape([0.1, 3., 2., 0.1, 3., 3., 0.1, 2., 0.1, 3., 0.1, 3.], [3, 4])
   type(fc2d_layer) :: fc
 
-  fc = fc2d_layer(hidden_size=5, activation=relu())
-  call fc % init([3, 4])
-  fc % in_proj % weights = 0.1
-  fc % in_proj % biases = 0.11
-  fc % out_proj % weights = 0.1
-  fc % out_proj % biases = 0.11
-
-  call test_fc2d_layer_forward(fc, ok, sample_input)
+  call test_fc2d_layer_forward(ok, sample_input)
+  call test_fc2d_layer_backward(&
+    ok, sample_input, sample_gradient,&
+    activation=relu(),&
+    expected_gradient_flat=[&
+      0.198, 0.486, 0.486,&
+      0.396, 0.972, 0.972,&
+      0.594, 1.458, 1.458,&
+      0.792, 1.944, 1.944&
+    ]&
+  )
+  call test_fc2d_layer_backward(&
+    ok, sample_input, sample_gradient,&
+    activation=sigmoid(),&
+    expected_gradient_flat=[&
+      0.01068044, 0.02734236, 0.00086295,&
+      0.02136087, 0.05140798, 0.00172666,&
+      0.03357822, 0.07555774, 0.00266102,&
+      0.04567052, 0.10338347, 0.0038053&
+    ]&
+  )
+  call test_fc2d_layer_backward(&
+    ok, sample_input, sample_gradient,&
+    activation=tanhf(),&
+    expected_gradient_flat=[&
+      3.7096841e-03, 9.3461145e-03, 1.1113838e-05,&
+      7.4193683e-03, 1.6985621e-02, 2.2227676e-05,&
+      1.2096796e-02, 2.4647098e-02, 3.3862932e-05,&
+      1.6650427e-02, 3.4423053e-02, 5.0007438e-05&
+    ]&
+  )
+  call test_fc2d_layer_backward(&
+    ok, sample_input, sample_gradient,&
+    activation=softplus(),&
+    expected_gradient_flat=[&
+      0.18651924, 0.45662752, 0.48513436,&
+      0.37303847, 0.9168981, 0.9702679,&
+      0.5578177, 1.3770795, 1.4553307,&
+      0.7427467, 1.8331366, 1.9401824&
+    ]&
+  )
 
   if (ok) then
     print '(a)', 'test_fc2d_layer: All tests passed.'
   else
     write(stderr, '(a)') 'test_fc2d_layer: One or more tests failed.'
-    stop 1
+    error stop 1
   end if
 
 contains
@@ -36,19 +69,34 @@ contains
     res = all(abs(x - y) <= (1e-06 + 1e-05 * abs(y)))
   end function allclose
 
-  subroutine test_fc2d_layer_forward(fc, ok, input)
-    type(fc2d_layer), intent(in out) :: fc
+  subroutine init_weigths(fc)
+    type(fc2d_layer) :: fc
+    fc % in_proj % weights = reshape(&
+        [0.1, 0.2, 0.3, 0.4, 0.1, 0.2, 0.3, 0.5, 0.1, 0.2, 0.4, 0.5, 0.1, 0.3, 0.4, 0.5, 0.2, 0.3, 0.4, 0.5],&
+        [4, 5]&
+    )
+    fc % in_proj % biases = 0.11
+    fc % out_proj % weights = 0.1
+    fc % out_proj % biases = 0.11
+  end subroutine init_weigths
+
+  subroutine test_fc2d_layer_forward(ok, input)
     logical, intent(in out) :: ok
     real, intent(in) :: input(3, 4)
+    type(fc2d_layer) :: fc
     real :: output_shape(2)
     real :: output_flat(12)
     real :: expected_shape(2) = [3, 4]
     real :: expected_output_flat(12) = [&
-        0.695, 0.2205, 1.246,&
-        0.695, 0.2205, 1.246,&
-        0.695, 0.2205, 1.246,&
-        0.695, 0.2205, 1.246&
+        1.509, 1.5594, 3.4098,&
+        1.509, 1.5594, 3.4098,&
+        1.509, 1.5594, 3.4098,&
+        1.509, 1.5594, 3.4098&
     ]
+
+    fc = fc2d_layer(hidden_size=5, activation=relu())
+    call fc % init([3, 4])
+    call init_weigths(fc)
 
     call fc % forward(input)
 
@@ -64,4 +112,35 @@ contains
     end if
   end subroutine test_fc2d_layer_forward
 
+  subroutine test_fc2d_layer_backward(ok, input, gradient, activation, expected_gradient_flat)
+    logical, intent(in out) :: ok
+    real, intent(in) :: input(3, 4)
+    real, intent(in) :: gradient(3, 4)
+    class(activation_function), intent(in) :: activation
+    real, intent(in) :: expected_gradient_flat(12)
+
+    type(fc2d_layer) :: fc
+
+    integer :: gradient_shape(2)
+    integer :: expected_gradient_shape(2) = [3, 4]
+    real :: gradient_flat(12)
+
+    fc = fc2d_layer(hidden_size=5, activation=activation)
+    call fc % init([3, 4])
+    call init_weigths(fc)
+
+    call fc % forward(input)
+    call fc % backward(input, gradient)
+
+    gradient_shape = shape(fc % gradient)
+    if (.not. all(gradient_shape.eq.expected_gradient_shape)) then
+      ok = .false.
+      write(stderr, '(a) (a)') 'backward returned incorrect gradient shape.. failed', fc % activation % get_name()
+    end if
+    gradient_flat = reshape(fc % gradient, shape(gradient_flat))
+    if (.not. allclose(gradient_flat, expected_gradient_flat)) then
+      ok = .false.
+      write(stderr, '(aa)') 'backward returned incorrect gradient values.. failed for ', fc % activation % get_name()
+    end if
+  end subroutine test_fc2d_layer_backward
 end program test_fc2d_layer

--- a/test/test_fc2d_layer.f90
+++ b/test/test_fc2d_layer.f90
@@ -1,0 +1,67 @@
+program test_fc2d_layer
+  use iso_fortran_env, only: stderr => error_unit
+  use nf_fc2d_layer, only: fc2d_layer
+  use nf, only: relu
+  implicit none
+
+  logical :: ok = .true.
+  real :: sample_input(3, 4) = reshape(&
+      [0.0, -10.1, 0.2, 10.3, 0.4, 10.5, -0.6, 10.7, 10.8, 0.9, 0.11, 0.12],&
+      [3, 4])
+  real :: sample_gradient(3, 4) = reshape([0.1, 3., 2., 0.1, 3., 3., 0.1, 2., 0.1, 3., 0.1, 3.], [3, 4])
+  type(fc2d_layer) :: fc
+
+  fc = fc2d_layer(hidden_size=5, activation=relu())
+  call fc % init([3, 4])
+  fc % in_proj % weights = 0.1
+  fc % in_proj % biases = 0.11
+  fc % out_proj % weights = 0.1
+  fc % out_proj % biases = 0.11
+
+  call test_fc2d_layer_forward(fc, ok, sample_input)
+
+  if (ok) then
+    print '(a)', 'test_fc2d_layer: All tests passed.'
+  else
+    write(stderr, '(a)') 'test_fc2d_layer: One or more tests failed.'
+    stop 1
+  end if
+
+contains
+  function allclose(x, y) result(res)
+    real, intent(in) :: x(:)
+    real, intent(in) :: y(:)
+    logical :: res
+
+    res = all(abs(x - y) <= (1e-06 + 1e-05 * abs(y)))
+  end function allclose
+
+  subroutine test_fc2d_layer_forward(fc, ok, input)
+    type(fc2d_layer), intent(in out) :: fc
+    logical, intent(in out) :: ok
+    real, intent(in) :: input(3, 4)
+    real :: output_shape(2)
+    real :: output_flat(12)
+    real :: expected_shape(2) = [3, 4]
+    real :: expected_output_flat(12) = [&
+        0.695, 0.2205, 1.246,&
+        0.695, 0.2205, 1.246,&
+        0.695, 0.2205, 1.246,&
+        0.695, 0.2205, 1.246&
+    ]
+
+    call fc % forward(input)
+
+    output_shape = shape(fc % output)
+    if (.not. all(output_shape.eq.expected_shape)) then
+      ok = .false.
+      write(stderr, '(a)') 'forward returned incorrect shape.. failed'
+    end if
+    output_flat = reshape(fc % output, shape(output_flat))
+    if (.not. allclose(output_flat, expected_output_flat)) then
+      ok = .false.
+      write(stderr, '(a)') 'forward returned incorrect values.. failed'
+    end if
+  end subroutine test_fc2d_layer_forward
+
+end program test_fc2d_layer


### PR DESCRIPTION
## Fully-Connected Layer for 2D Shapes

Also known as MLP, FeedForward, etc. A common component of neural networks, including transformers. The idea is very simple: first linear transformation => activation => second linear transformation.

**This is the last piece of tranformer architecture.**
When #203, #205 and this one are merged. We can start adding transformer encoders and decoders.

## Problem

Softmax derivative here is incorrect. [This implementation](https://github.com/modern-fortran/neural-fortran/blob/ed8b3404264c0932b8c6d712f1dc29203f3d69e8/src/nf/nf_activation.f90#L391) is actually prime of logistic function which does not equivalent to softmax.
Derivative of softmax w.r.t. to each element in input requires computation of of Jacobian matrix:

$jacobian_{i, j} = \pmatrix{\frac{dsofmax_1}{dx_1} & ... & \frac{dsofmax_1}{dx_j} \cr ... & ... & ... \cr\frac{dsofmax_i}{dx_1} & ... & \frac{dsofmax_i}{dx_j} }$
$\frac{dsoftmax}{dx_i} = gradient \times jacobian$

Where:

* $\frac{dsoftmax_i}{x_j} = softmax(x_j) \cdot (\alpha - softmax(x_i))$ where $\alpha$ is $1$ for $i = j$, $0$ otherwise

* $x$ is the input sequence

Similar to my implementation for MultiHead Attention [here](https://github.com/modern-fortran/neural-fortran/blob/ed8b3404264c0932b8c6d712f1dc29203f3d69e8/src/nf/nf_multihead_attention_submodule.f90#L63).

## Possible Solutions
It is not easy to resolve as `activation_function` doesn't accept input, so:
* Do nothing, I added crutch that throws an error when `softmax` is passed as activation
* Make softmax a layer without parameters rather than an activation function, this will work
* Make a wrapper `activation_layer` that extends `base_layer` and accepts activation function 