### PR TITLE
Multihead Attention Fixes

### DIFF
--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -41,17 +41,17 @@ module nf_multihead_attention_layer
     real, allocatable :: o_input(:, :)
 
     ! temporary storages for forward and backward passes
-    real, allocatable, private :: normalized_attention(:, :, :)
-    real, allocatable, private :: q_or_dq(:, :, :)
-    real, allocatable, private :: k_or_dk(:, :, :)
-    real, allocatable, private :: v_or_dv(:, :, :)
-    real, allocatable, private :: d_output(:, :, :)
-    real, allocatable, private :: v_heads(:, :, :)
-    real, allocatable, private :: k_heads(:, :, :)
-    real, allocatable, private :: q_heads(:, :, :)
-    real, allocatable, private :: d_sdpa(:, :)
-    real, allocatable, private :: jacobian(:, :)
-    real, allocatable, private :: d_normalize(:, :, :)
+    real, allocatable :: normalized_attention(:, :, :)
+    real, allocatable :: q_or_dq(:, :, :)
+    real, allocatable :: k_or_dk(:, :, :)
+    real, allocatable :: v_or_dv(:, :, :)
+    real, allocatable :: d_output(:, :, :)
+    real, allocatable :: v_heads(:, :, :)
+    real, allocatable :: k_heads(:, :, :)
+    real, allocatable :: q_heads(:, :, :)
+    real, allocatable :: d_sdpa(:, :)
+    real, allocatable :: jacobian(:, :)
+    real, allocatable :: d_normalize(:, :, :)
   contains
 
     procedure :: common_backward

--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -56,6 +56,8 @@ module nf_multihead_attention_layer
 
     procedure :: common_backward
     procedure :: common_forward
+    procedure :: sdpa_forward
+    procedure :: sdpa_backward
     procedure :: get_num_params
     procedure :: get_params
     procedure :: get_gradients
@@ -101,6 +103,17 @@ module nf_multihead_attention_layer
       real, intent(in) :: query(:, :), key(:, :), value(:, :)
       real, optional, intent(in) :: attention_mask(:, :)
     end subroutine common_forward
+
+    pure module subroutine sdpa_forward(self, attention_mask)
+      class(multihead_attention_layer), intent(in out) :: self
+      real, intent(in), optional :: attention_mask(:, :)
+    end subroutine sdpa_forward
+
+    pure module subroutine sdpa_backward(self, gradient, attention_mask)
+      class(multihead_attention_layer), intent(in out) :: self
+      real, intent(in) :: gradient(:, :)
+      real, intent(in), optional :: attention_mask(:, :)
+    end subroutine sdpa_backward
 
     pure module subroutine init(self, input_shape)
       !! Initialize the layer data structures.

--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -158,18 +158,18 @@ module nf_multihead_attention_layer
     end function get_num_params
 
     module function get_params(self) result(params)
-      class(multihead_attention_layer), intent(in), target :: self
+      class(multihead_attention_layer), intent(in) :: self
       real, allocatable :: params(:)
     end function get_params
 
     module function get_gradients(self) result(gradients)
-      class(multihead_attention_layer), intent(in), target :: self
+      class(multihead_attention_layer), intent(in) :: self
       real, allocatable :: gradients(:)
     end function get_gradients
 
     module subroutine set_params(self, params)
       class(multihead_attention_layer), intent(in out) :: self
-      real, intent(in), target :: params(:)
+      real, intent(in) :: params(:)
     end subroutine set_params
 
     module subroutine init_base(self, input_shape)

--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -41,6 +41,7 @@ module nf_multihead_attention_layer
     real, allocatable :: o_input(:, :)
 
     ! temporary storages for forward and backward passes
+    real, allocatable, private :: normalized_attention(:, :, :)
     real, allocatable, private :: q_or_dq(:, :, :)
     real, allocatable, private :: k_or_dk(:, :, :)
     real, allocatable, private :: v_or_dv(:, :, :)

--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -39,6 +39,18 @@ module nf_multihead_attention_layer
     real, allocatable :: k_input(:, :)
     real, allocatable :: v_input(:, :)
     real, allocatable :: o_input(:, :)
+
+    ! temporary storages for forward and backward passes
+    real, allocatable, private :: q_or_dq(:, :, :)
+    real, allocatable, private :: k_or_dk(:, :, :)
+    real, allocatable, private :: v_or_dv(:, :, :)
+    real, allocatable, private :: d_output(:, :, :)
+    real, allocatable, private :: v_heads(:, :, :)
+    real, allocatable, private :: k_heads(:, :, :)
+    real, allocatable, private :: q_heads(:, :, :)
+    real, allocatable, private :: d_sdpa(:, :)
+    real, allocatable, private :: jacobian(:, :)
+    real, allocatable, private :: d_normalize(:, :, :)
   contains
 
     procedure :: common_backward

--- a/src/nf/nf_multihead_attention.f90
+++ b/src/nf/nf_multihead_attention.f90
@@ -81,7 +81,7 @@ module nf_multihead_attention_layer
 
   interface
 
-    pure module subroutine common_backward(self, input, gradient)
+    pure module subroutine common_backward(self, input, gradient, attention_mask)
       !! General backprop for MultiHead Attention mechanism
       !! Might be used for both Self and Cross Attention
       !! Self Attention: sum output gradients
@@ -89,15 +89,17 @@ module nf_multihead_attention_layer
       class(multihead_attention_layer), intent(in out) :: self
       real, intent(in) :: input(:, :)
       real, intent(in) :: gradient(:, :)
+      real, optional, intent(in) :: attention_mask(:, :)
     end subroutine common_backward
 
-    pure module subroutine common_forward(self, query, key, value)
+    pure module subroutine common_forward(self, query, key, value, attention_mask)
       !! General forward propagation for MultiHead Attention Mechanism
       !! Might be used for both Self and Cross Attention
       !! Self Attention: pass the same value thrice
       !! Cross Attention: pass three values for your query, key and value
       class(multihead_attention_layer), intent(in out) :: self
       real, intent(in) :: query(:, :), key(:, :), value(:, :)
+      real, optional, intent(in) :: attention_mask(:, :)
     end subroutine common_forward
 
     pure module subroutine init(self, input_shape)
@@ -132,7 +134,7 @@ module nf_multihead_attention_layer
       !! Output dims: sequence_length, sequence_length, n_heads
       class(multihead_attention_layer), intent(in out) :: self
       !! (sequence_length, sequence_length, n_heads)
-      real, optional, intent(in) :: attention_mask(:, :, :)
+      real, optional, intent(in) :: attention_mask(:, :)
       !! (sequence_length, sequence_length, n_heads)
     end subroutine normalize_attention_matrix
 

--- a/src/nf/nf_multihead_attention_submodule.f90
+++ b/src/nf/nf_multihead_attention_submodule.f90
@@ -187,7 +187,7 @@ contains
   end function get_num_params
 
   module function get_params(self) result(params)
-    class(multihead_attention_layer), intent(in), target :: self
+    class(multihead_attention_layer), intent(in) :: self
     real, allocatable :: params(:)
 
     params = [&
@@ -203,7 +203,7 @@ contains
   end function get_params
 
   module function get_gradients(self) result(gradients)
-    class(multihead_attention_layer), intent(in), target :: self
+    class(multihead_attention_layer), intent(in) :: self
     real, allocatable :: gradients(:)
 
     gradients = [ &
@@ -220,8 +220,7 @@ contains
 
   module subroutine set_params(self, params)
     class(multihead_attention_layer), intent(in out) :: self
-    real, intent(in), target :: params(:)
-    real, pointer :: p_(:,:) => null()
+    real, intent(in) :: params(:)
     integer :: i, j, window
 
     ! check if the number of parameters is correct

--- a/src/nf/nf_multihead_attention_submodule.f90
+++ b/src/nf/nf_multihead_attention_submodule.f90
@@ -21,6 +21,10 @@ contains
 
     integer :: head, seq, i, j
 
+    self % v_heads = self % split_heads(self % value_layer % output)
+    self % k_heads = self % split_heads(self % key_layer % output)
+    self % q_heads = self % split_heads(self % query_layer % output)
+
     ! bakward through attention mechanism
     call self % sdpa_backward(gradient, attention_mask)
 
@@ -80,9 +84,6 @@ contains
 
     ! split heads from output gradient
     self % d_output = self % split_heads(self % output_layer % gradient)
-    self % v_heads = self % split_heads(self % value_layer % output)
-    self % k_heads = self % split_heads(self % key_layer % output)
-    self % q_heads = self % split_heads(self % query_layer % output)
 
     ! iterate over heads to calculate deltas for each of them
     do concurrent(head = 1: self % n_heads)

--- a/src/nf/nf_self_attention_layer.f90
+++ b/src/nf/nf_self_attention_layer.f90
@@ -35,14 +35,15 @@ contains
     res % n_heads = n_heads
   end function self_attention_layer_cons
 
-  pure module subroutine backward(self, input, gradient)
+  pure module subroutine backward(self, input, gradient, attention_mask)
     !! Self Attention back propagation
     !! Returns sum of Query, Key and Value gradients
     class(self_attention_layer), intent(in out) :: self
     real, intent(in) :: input(:, :)
     real, intent(in) :: gradient(:, :)
+    real, intent(in), optional :: attention_mask(:, :)
 
-    call self % common_backward(input, gradient)
+    call self % common_backward(input, gradient, attention_mask)
     self % gradient = &
         self % query_layer % gradient &
         + self % key_layer % gradient &

--- a/test/test_multihead_attention_layer.f90
+++ b/test/test_multihead_attention_layer.f90
@@ -256,7 +256,6 @@ contains
     call attention % common_backward(input, gradient)
 
     ! sample for Self Attention: sum of output gradients
-    ! FIXME: remove reshapes when linear2d situation is resolved
     output = &
         attention % query_layer % gradient &
         + attention % key_layer % gradient &

--- a/test/test_multihead_attention_layer.f90
+++ b/test/test_multihead_attention_layer.f90
@@ -258,9 +258,9 @@ contains
     ! sample for Self Attention: sum of output gradients
     ! FIXME: remove reshapes when linear2d situation is resolved
     output = &
-        reshape(attention % query_layer % gradient, [attention % sequence_length, attention % model_dimension]) &
-        + reshape(attention % key_layer % gradient, [attention % sequence_length, attention % model_dimension]) &
-        + reshape(attention % value_layer % gradient, [attention % sequence_length, attention % model_dimension])
+        attention % query_layer % gradient &
+        + attention % key_layer % gradient &
+        + attention % value_layer % gradient
 
     output_shape = shape(output)
     if (.not. all(output_shape.eq.expected_shape)) then


### PR DESCRIPTION
### Minor Changes to MHA
1. Memory allocation optimization
2. Making attention masks usable (with test)
3. Minor cleanup (unused variables etc). BTW, perhaps, add some static analyzer to CI?
4. A bit of reshuffling inside MHA forward and backward calls for better inheritance. Reason for those changes is that I'm making Llama Attention which is subclass of MHA. Source here: https://github.com/OneAdder/llm.f/blob/master/src/llama_attention.f90