### PR TITLE
linear2d_layer_no_bias: add optional argument to disable biases

### DIFF
--- a/src/nf/nf_layer_constructors.f90
+++ b/src/nf/nf_layer_constructors.f90
@@ -213,12 +213,14 @@ module nf_layer_constructors
         !! Resulting layer instance
     end function reshape
 
-    module function linear2d(out_features) result(res)
+    module function linear2d(out_features, biases) result(res)
       !! Rank-2 (sequence_length, out_features) linear layer constructor.
       !! sequence_length is determined at layer initialization, based on the
       !! output shape of the previous layer.
       integer, intent(in) :: out_features
         !! Number of output features
+      logical, optional :: biases
+        !! Whether to use biases or not
       type(layer) :: res
         !! Resulting layer instance
     end function linear2d

--- a/src/nf/nf_layer_constructors_submodule.f90
+++ b/src/nf/nf_layer_constructors_submodule.f90
@@ -163,12 +163,13 @@ contains
   end function reshape
 
 
-  module function linear2d(out_features) result(res)
+  module function linear2d(out_features, biases) result(res)
     integer, intent(in) :: out_features
+    logical, optional :: biases
     type(layer) :: res
 
     res % name = 'linear2d'
-    allocate(res % p, source=linear2d_layer(out_features))
+    allocate(res % p, source=linear2d_layer(out_features, biases))
 
   end function linear2d
 

--- a/src/nf/nf_linear2d_layer.f90
+++ b/src/nf/nf_linear2d_layer.f90
@@ -9,7 +9,8 @@ module nf_linear2d_layer
   public :: linear2d_layer
 
   type, extends(base_layer) :: linear2d_layer
-    integer :: sequence_length, in_features, out_features, batch_size
+    integer :: sequence_length, in_features, out_features
+    logical :: use_biases
 
     real, allocatable :: weights(:,:)
     real, allocatable :: biases(:)
@@ -31,8 +32,9 @@ module nf_linear2d_layer
   end type linear2d_layer
 
   interface linear2d_layer
-    module function linear2d_layer_cons(out_features) result(res)
+    module function linear2d_layer_cons(out_features, biases) result(res)
       integer, intent(in) :: out_features
+      logical, optional, intent(in) :: biases
       type(linear2d_layer) :: res
     end function linear2d_layer_cons
   end interface linear2d_layer


### PR DESCRIPTION
### Add option to disable biases
Simple additional option. Removing biases helps speed up inference. This technique is used in Llama and, to an extent, in Qwen. Being able to disable biases here is a simple quality of life addition