### PR TITLE
fix #233 - make factories impure

### DIFF
--- a/src/nf/nf_activation.f90
+++ b/src/nf/nf_activation.f90
@@ -733,7 +733,7 @@ contains
   end function eval_3d_celu_prime
 
   ! Utility Functions
-  pure function get_activation_by_name(activation_name) result(res)
+  function get_activation_by_name(activation_name) result(res)
     character(len=*), intent(in) :: activation_name
     class(activation_function), allocatable :: res
 

--- a/src/nf/nf_optimizers.f90
+++ b/src/nf/nf_optimizers.f90
@@ -316,7 +316,7 @@ contains
 
   ! Utility Functions
   !! Returns the default optimizer corresponding to the provided name
-  pure function get_optimizer_by_name(optimizer_name) result(res)
+  function get_optimizer_by_name(optimizer_name) result(res)
     character(len=*), intent(in) :: optimizer_name
     class(optimizer_base_type), allocatable :: res
 


### PR DESCRIPTION
fixes #233

Pure functions get_activation_by_name and get_optimizer_by_name construct polymorphic function results.  Removing `pure` enables building with the LLVM flang-new compiler.

Although Fortran 2003 allowed pure functions with allocatable polymorphic results, subsequent standards disallowed such functions. Using this Fortran 2003 feature blocks building with the LLVM and NAG compilers and likely will block building with future versions of gfortran once GCC issue 78640 has been fixed.  (See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=78640.)

TODO: A subsequent error still blocks building with NAG, which this commit does not address.