### PR TITLE
Fix ENV variable hints in Find module to use underscores instead of hyphens

### DIFF
--- a/cmake/Findneural-fortran.cmake
+++ b/cmake/Findneural-fortran.cmake
@@ -4,16 +4,16 @@
 # neural-fortran_LIBRARIES - List of libraries when using neural-fortran.
 # neural-fortran_FOUND - True if neural-fortran found.
 #
-# To use neural-fortran_ROOT_DIR to specify the prefix directory of neural-fortran
+# To use neural_fortran_ROOT_DIR (env) or -Dneural-fortran_ROOT_DIR (cmake) to specify the prefix directory of neural-fortran
 
 
 find_path(neural-fortran_INCLUDE_DIRS
   NAMES nf.mod
-  HINTS ${neural-fortran_ROOT_DIR}/include ENV neural-fortran_INCLUDE_DIR)
+  HINTS ${neural-fortran_ROOT_DIR}/include ENV neural_fortran_INCLUDE_DIR)
 
 find_library(neural-fortran_LIBRARIES
   NAMES neural-fortran
-  HINTS ${neural-fortran_ROOT_DIR}/lib ENV neural-fortran_LIB_DIR)
+  HINTS ${neural-fortran_ROOT_DIR}/lib ENV neural_fortran_LIB_DIR)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(neural-fortran DEFAULT_MSG neural-fortran_LIBRARIES neural-fortran_INCLUDE_DIRS)

--- a/cmake/Findneural-fortran.cmake
+++ b/cmake/Findneural-fortran.cmake
@@ -9,11 +9,15 @@
 
 find_path(neural-fortran_INCLUDE_DIRS
   NAMES nf.mod
-  HINTS ${neural-fortran_ROOT_DIR}/include ENV neural_fortran_INCLUDE_DIR)
+  HINTS ${neural-fortran_ROOT_DIR}/include
+        $ENV{neural_fortran_ROOT_DIR}/include
+        $ENV{neural_fortran_INCLUDE_DIR})
 
 find_library(neural-fortran_LIBRARIES
   NAMES neural-fortran
-  HINTS ${neural-fortran_ROOT_DIR}/lib ENV neural_fortran_LIB_DIR)
+  HINTS ${neural-fortran_ROOT_DIR}/lib
+        $ENV{neural_fortran_ROOT_DIR}/lib
+        $ENV{neural_fortran_LIB_DIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(neural-fortran DEFAULT_MSG neural-fortran_LIBRARIES neural-fortran_INCLUDE_DIRS)


### PR DESCRIPTION
## Problem

Bash does not allow hyphens in environment variable names. As a result, setting `neural-fortran_ROOT_DIR` as an environment variable (e.g. via a modulefile) fails with:

```
-bash: neural-fortran_ROOT_DIR=/path/to/prefix: No such file or directory
-bash: export: `neural-fortran_ROOT_DIR': not a valid identifier
```

## Solution

Update `Findneural-fortran.cmake` to use bash-compatible (underscore) environment variable names:

- Add `$ENV{neural_fortran_ROOT_DIR}` as a prefix hint, so modulefiles can set:
```
setenv("neural_fortran_ROOT_DIR", pkgdir)
```
- Rename the specific path override env vars to use underscores:
  - `neural-fortran_INCLUDE_DIR` → `neural_fortran_INCLUDE_DIR`
  - `neural-fortran_LIB_DIR` → `neural_fortran_LIB_DIR`
- Use explicit `$ENV{}` expansion in `HINTS` rather than the `ENV` keyword to avoid `PATH_SUFFIXES` being incorrectly applied to direct-path env vars.

## Compatibility

Fully backward compatible. The CMake variable `-Dneural-fortran_ROOT_DIR` is unaffected and continues to work as before. The old hyphenated env var names were never usable in bash anyway, so nothing is lost.